### PR TITLE
Allow unspecified time step unit for experiments.

### DIFF
--- a/intern/resource/boss/resource.py
+++ b/intern/resource/boss/resource.py
@@ -200,7 +200,7 @@ class ExperimentResource(BossResource):
         self.num_time_samples = num_time_samples
 
         self._valid_time_units = [
-            'nanoseconds', 'microseconds', 'milliseconds', 'seconds']
+            '', 'nanoseconds', 'microseconds', 'milliseconds', 'seconds']
         self.time_step = time_step
         self._time_step_unit = self.validate_time_units(time_step_unit)
 

--- a/intern/resource/boss/tests/test_experiment.py
+++ b/intern/resource/boss/tests/test_experiment.py
@@ -48,6 +48,10 @@ class TestExperimentResource(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.er.validate_hierarchy_method('slice')
 
+    def test_validate_time_units_blank(self):
+        exp = ''
+        self.assertEqual(exp, self.er.validate_time_units(''))
+
     def test_validate_time_units_ns(self):
         exp = 'nanoseconds'
         self.assertEqual(exp, self.er.validate_time_units(exp))


### PR DESCRIPTION
The management console allows creation of experiments w/o specifying the
time step.  The REST API will return a blank string for the time step
unit in this case.

Addresses https://github.com/jhuapl-boss/intern/issues/7
