### PR TITLE
Renamed fully_initialized to cutout_ready.

### DIFF
--- a/intern/remote/boss/tests/int_test_project_v1.py
+++ b/intern/remote/boss/tests/int_test_project_v1.py
@@ -283,7 +283,7 @@ class ProjectServiceTest_v1(unittest.TestCase):
 
         # This is not an exhaustive list of attributes, but they are the
         # important ones for correct interaction with the volume service.
-        self.assertTrue(actual.fully_initialized)
+        self.assertTrue(actual.cutout_ready)
         self.assertEqual(chan.datatype, actual.datatype)
         self.assertEqual(chan.default_time_sample, actual.default_time_sample)
         self.assertEqual(chan.base_resolution, actual.base_resolution)

--- a/intern/resource/boss/resource.py
+++ b/intern/resource/boss/resource.py
@@ -400,7 +400,8 @@ class CoordinateFrameResource(BossResource):
 
 class PartialChannelResourceError(Exception):
     """
-    Indicate that the ChannelResource is not fully initialized.
+    Indicate that the ChannelResource is not fully initialized for use with
+    the cutout service.
     """
     pass
 
@@ -418,7 +419,7 @@ class ChannelResource(BossResource):
         _type (string): 'image' or 'annotation'
         _valid_datatypes (list[string]): Allowed data type values (static variable).
         _datatype (string):
-        _fully_initialized (bool): True if datatype specified during instantiation.
+        _cutout_ready (bool): True if datatype specified during instantiation.
     """
 
     _valid_datatypes = ['uint8', 'uint16', 'uint64']
@@ -463,11 +464,11 @@ class ChannelResource(BossResource):
         # Class is considered fully initialized if datatype set during
         # initialization.
         if datatype == '':
-            self._fully_initialized = False
+            self._cutout_ready = False
             # Default to uint8.
             datatype = 'uint8'
         else:
-            self._fully_initialized = True
+            self._cutout_ready = True
         self._datatype = self.validate_datatype(datatype)
 
         self.sources = sources
@@ -500,13 +501,13 @@ class ChannelResource(BossResource):
         return True
 
     @property
-    def fully_initialized(self):
-        """Is this channel fully configured?
+    def cutout_ready(self):
+        """Is this channel fully configured for doing cutouts?
 
         Returns:
             (bool) True if the datatype was explicitly set by the user.
         """
-        return self._fully_initialized
+        return self._cutout_ready
 
     @property
     def sources(self):
@@ -567,7 +568,7 @@ class ChannelResource(BossResource):
             ValueError
         """
         self._datatype = self.validate_datatype(value)
-        self._fully_initialized = True
+        self._cutout_ready = True
 
     def validate_type(self, value):
         lowered = value.lower()

--- a/intern/resource/boss/tests/test_channel.py
+++ b/intern/resource/boss/tests/test_channel.py
@@ -21,20 +21,20 @@ class TestChannelResource(unittest.TestCase):
 
     def test_init_status_false(self):
         chan = ChannelResource('somechan', 'foo', 'bar')
-        self.assertFalse(chan.fully_initialized)
+        self.assertFalse(chan.cutout_ready)
 
     def test_channel_defaults_to_uint8(self):
         chan = ChannelResource('somechan', 'foo', 'bar')
         self.assertEqual('uint8', chan.datatype)
 
-    def test_setting_datatype_means_fully_initialized_at_construction(self):
+    def test_setting_datatype_means_cutout_ready_at_construction(self):
         chan = ChannelResource('somechan', 'foo', 'bar', datatype='uint8')
-        self.assertTrue(chan.fully_initialized)
+        self.assertTrue(chan.cutout_ready)
 
-    def test_setting_datatype_means_fully_initialized(self):
+    def test_setting_datatype_means_cutout_ready(self):
         chan = ChannelResource('somechan', 'foo', 'bar')
         chan.datatype = 'uint16'
-        self.assertTrue(chan.fully_initialized)
+        self.assertTrue(chan.cutout_ready)
 
     def test_default_source_is_empty(self):
         self.assertEqual([], self.chan.sources)

--- a/intern/service/boss/volume.py
+++ b/intern/service/boss/volume.py
@@ -30,7 +30,7 @@ def check_channel(fcn):
         if not isinstance(args[1], ChannelResource):
             raise RuntimeError('resource must be an instance of intern.resource.boss.ChannelResource.')
 
-        if not args[1].fully_initialized:
+        if not args[1].cutout_ready:
             raise PartialChannelResourceError(
                     'ChannelResource not fully initialized.  Use intern.remote.BossRemote.get_channel({}, {}, {})'.format(
                         args[1].name, args[1].coll_name, args[1].exp_name))


### PR DESCRIPTION
This is a more appropriate name for the ChannelResource's property as discussed in https://github.com/jhuapl-boss/intern/pull/4