### PR TITLE
explicitly set datatype for cutouts

### DIFF
--- a/intern/service/boss/v1/volume.py
+++ b/intern/service/boss/v1/volume.py
@@ -137,7 +137,7 @@ class VolumeService_1(BaseVersion):
                 z_range[1] - z_range[0],
                 y_range[1] - y_range[0],
                 x_range[1] - x_range[0]
-            ))
+            ), dtype=resource.datatype)
 
             for b in blocks:
                 _data = self.get_cutout(


### PR DESCRIPTION
This closes #6. Will return cutout in the correct datatype based on the channel_resource.