### PR TITLE
No-cache get_cutout() feature

### DIFF
--- a/docs/remote/boss/remote.m.html
+++ b/docs/remote/boss/remote.m.html
@@ -3735,7 +3735,7 @@ returned is cuboid aligned.</p>
             
   <div class="item">
     <div class="name def" id="intern.remote.boss.remote.BossRemote.get_cutout">
-    <p>def <span class="ident">get_cutout</span>(</p><p>self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[])</p>
+    <p>def <span class="ident">get_cutout</span>(</p><p>self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[], no_cache=False, **kwargs)</p>
     </div>
     
 
@@ -3750,6 +3750,7 @@ returned is cuboid aligned.</p>
 &emsp;&emsp;&emsp;&emsp;<b>z_range (list[int])</b>: z range such as [10, 20] which means z&gt;=10 and z&lt;20.<br />
 &emsp;&emsp;&emsp;&emsp;<b>time_range (optional [list[int]])</b>: time range such as [30, 40] which means t&gt;=30 and t&lt;40.<br />
 &emsp;&emsp;&emsp;&emsp;<b>id_list (optional [list])</b>: list of object ids to filter the cutout by.</p>
+&emsp;&emsp;&emsp;&emsp;<b>no_cache (optional [boolean])</b>: specifies the use of cache to be True or False. </p>
 <h2 style='font-size:125% !important'>Returns</h2>
 
 <p>&emsp;&emsp;&emsp;&emsp;<b>()</b>: Return type depends on volume service's implementation.</p>
@@ -3771,6 +3772,7 @@ Other exceptions may be raised depending on the volume service's implementation.
         z_range (list[int]): z range such as [10, 20] which means z>=10 and z<20.
         time_range (optional [list[int]]): time range such as [30, 40] which means t>=30 and t<40.
         id_list (optional [list]): list of object ids to filter the cutout by.
+        no_cache (optional [boolean]): specifies the use of cache to be True or False. 
     Returns:
         (): Return type depends on volume service's implementation.
     Raises:

--- a/intern/remote/boss/remote.py
+++ b/intern/remote/boss/remote.py
@@ -853,6 +853,11 @@ class BossRemote(Remote):
     def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[], no_cache=False, **kwargs):
             """Get a cutout from the volume service.
 
+            Note that no_cache=True is desirable when reading large amounts of
+            data at once.  In these cases, the data is not first read into the
+            cache, but instead, is sent directly from the data store to the
+            requester.
+
             Args:
                 resource (intern.resource.boss.resource.ChannelResource): Channel or layer resource.
                 resolution (int): 0 indicates native resolution.

--- a/intern/remote/boss/remote.py
+++ b/intern/remote/boss/remote.py
@@ -849,3 +849,25 @@ class BossRemote(Remote):
         """
         self.metadata_service.set_auth(self._token_metadata)
         self.metadata_service.delete(resource, keys)
+
+    def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[], no_cache=False, **kwargs):
+            """Get a cutout from the volume service.
+
+            Args:
+                resource (intern.resource.boss.resource.ChannelResource): Channel or layer resource.
+                resolution (int): 0 indicates native resolution.
+                x_range (list[int]): x range such as [10, 20] which means x>=10 and x<20.
+                y_range (list[int]): y range such as [10, 20] which means y>=10 and y<20.
+                z_range (list[int]): z range such as [10, 20] which means z>=10 and z<20.
+                time_range (optional [list[int]]): time range such as [30, 40] which means t>=30 and t<40.
+                id_list (optional [list[int]]): list of object ids to filter the cutout by.
+                no_cache (optional [boolean]): specifies the use of cache to be True or False. 
+
+            Returns:
+                (numpy.array): A 3D or 4D (time) numpy matrix in (time)ZYX order.
+
+            Raises:
+                requests.HTTPError on error.
+            """
+
+            return self._volume.get_cutout(resource, resolution, x_range, y_range, z_range, time_range, id_list, no_cache, **kwargs)

--- a/intern/remote/remote.py
+++ b/intern/remote/remote.py
@@ -125,7 +125,7 @@ class Remote(object):
         """
         return self._project.list(**kwargs)
 
-    def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[]):
+    def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[], **kwargs):
         """Get a cutout from the volume service.
 
         Args:
@@ -148,7 +148,7 @@ class Remote(object):
         if not resource.valid_volume():
             raise RuntimeError('Resource incompatible with the volume service.')
         return self._volume.get_cutout(
-            resource, resolution, x_range, y_range, z_range, time_range, id_list)
+            resource, resolution, x_range, y_range, z_range, time_range, id_list, **kwargs)
 
     def create_cutout(self, resource, resolution, x_range, y_range, z_range, data, time_range=None):
         """Upload a cutout to the volume service.

--- a/intern/service/boss/baseversion.py
+++ b/intern/service/boss/baseversion.py
@@ -147,7 +147,7 @@ class BaseVersion(object):
         return urlWithKey + '&value=' + str(value)
 
     def build_cutout_url(
-        self, resource, url_prefix, resolution, x_range, y_range, z_range, time_range=None, id_list=[]):
+        self, resource, url_prefix, resolution, x_range, y_range, z_range, time_range=None, id_list=[], no_cache):
         """Build the url to access the cutout function of the Boss' volume service.
 
         Args:
@@ -180,6 +180,9 @@ class BaseVersion(object):
 
         if len(id_list) > 0:
             urlWithParams += '?filter=' + self.convert_int_list_to_comma_sep_str(id_list)
+
+        if no_cash:
+            urlWithParams += 'no-cache=true' + '/' 
 
         return urlWithParams
 
@@ -250,7 +253,7 @@ class BaseVersion(object):
 
     def get_cutout_request(
         self, resource, method, content, url_prefix, token,
-        resolution, x_range, y_range, z_range, time_range, numpyVolume=None, id_list=[]):
+        resolution, x_range, y_range, z_range, time_range, numpyVolume=None, id_list=[], no_cache=False):
 
         """Create a request for working with cutouts (part of the Boss' volume service).
 
@@ -275,7 +278,7 @@ class BaseVersion(object):
             RuntimeError if url_prefix is None or an empty string.
         """
         url = self.build_cutout_url(
-            resource, url_prefix, resolution, x_range, y_range, z_range, time_range, id_list)
+            resource, url_prefix, resolution, x_range, y_range, z_range, time_range, id_list, no_cache)
         headers = self.get_headers(content, token)
         return Request(method, url, headers = headers, data = numpyVolume)
 

--- a/intern/service/boss/baseversion.py
+++ b/intern/service/boss/baseversion.py
@@ -253,7 +253,7 @@ class BaseVersion(object):
 
     def get_cutout_request(
         self, resource, method, content, url_prefix, token,
-        resolution, x_range, y_range, z_range, time_range, no_cache=False, numpyVolume=None, id_list=[]):
+        resolution, x_range, y_range, z_range, time_range, numpyVolume=None, id_list=[], no_cache=False,):
 
         """Create a request for working with cutouts (part of the Boss' volume service).
 

--- a/intern/service/boss/baseversion.py
+++ b/intern/service/boss/baseversion.py
@@ -147,7 +147,7 @@ class BaseVersion(object):
         return urlWithKey + '&value=' + str(value)
 
     def build_cutout_url(
-        self, resource, url_prefix, resolution, x_range, y_range, z_range, time_range=None, id_list=[], no_cache):
+        self, resource, url_prefix, resolution, x_range, y_range, z_range, no_cache, time_range=None, id_list=[]):
         """Build the url to access the cutout function of the Boss' volume service.
 
         Args:
@@ -181,8 +181,8 @@ class BaseVersion(object):
         if len(id_list) > 0:
             urlWithParams += '?filter=' + self.convert_int_list_to_comma_sep_str(id_list)
 
-        if no_cash:
-            urlWithParams += 'no-cache=true' + '/' 
+        if no_cache:
+            urlWithParams += '?no-cache=true' + '/' 
 
         return urlWithParams
 
@@ -253,7 +253,7 @@ class BaseVersion(object):
 
     def get_cutout_request(
         self, resource, method, content, url_prefix, token,
-        resolution, x_range, y_range, z_range, time_range, numpyVolume=None, id_list=[], no_cache=False):
+        resolution, x_range, y_range, z_range, time_range, no_cache=False, numpyVolume=None, id_list=[]):
 
         """Create a request for working with cutouts (part of the Boss' volume service).
 
@@ -278,7 +278,7 @@ class BaseVersion(object):
             RuntimeError if url_prefix is None or an empty string.
         """
         url = self.build_cutout_url(
-            resource, url_prefix, resolution, x_range, y_range, z_range, time_range, id_list, no_cache)
+            resource, url_prefix, resolution, x_range, y_range, z_range, no_cache, time_range,  id_list)
         headers = self.get_headers(content, token)
         return Request(method, url, headers = headers, data = numpyVolume)
 

--- a/intern/service/boss/baseversion.py
+++ b/intern/service/boss/baseversion.py
@@ -147,7 +147,7 @@ class BaseVersion(object):
         return urlWithKey + '&value=' + str(value)
 
     def build_cutout_url(
-        self, resource, url_prefix, resolution, x_range, y_range, z_range, no_cache, time_range=None, id_list=[]):
+        self, resource, url_prefix, resolution, x_range, y_range, z_range,  time_range=None, id_list=[], no_cache=False):
         """Build the url to access the cutout function of the Boss' volume service.
 
         Args:
@@ -278,7 +278,7 @@ class BaseVersion(object):
             RuntimeError if url_prefix is None or an empty string.
         """
         url = self.build_cutout_url(
-            resource, url_prefix, resolution, x_range, y_range, z_range, no_cache, time_range,  id_list)
+            resource, url_prefix, resolution, x_range, y_range, z_range, time_range,  id_list, no_cache)
         headers = self.get_headers(content, token)
         return Request(method, url, headers = headers, data = numpyVolume)
 

--- a/intern/service/boss/v1/volume.py
+++ b/intern/service/boss/v1/volume.py
@@ -93,7 +93,7 @@ class VolumeService_1(BaseVersion):
 
     def get_cutout(
             self, resource, resolution, x_range, y_range, z_range, time_range, id_list,
-            url_prefix, auth, session, send_opts
+            url_prefix, auth, session, send_opts, **kwargs
         ):
         """
         Upload a cutout to the Boss data store.
@@ -157,7 +157,7 @@ class VolumeService_1(BaseVersion):
             resource, 'GET', 'application/blosc',
             url_prefix, auth,
             resolution, x_range, y_range, z_range, time_range,
-            id_list=id_list
+            id_list=id_list, **kwargs
         )
         prep = session.prepare_request(req)
         # Hack in Accept header for now.

--- a/intern/service/boss/v1/volume.py
+++ b/intern/service/boss/v1/volume.py
@@ -111,6 +111,7 @@ class VolumeService_1(BaseVersion):
             auth (string): Token to send in the request header.
             session (requests.Session): HTTP session to use for request.
             send_opts (dictionary): Additional arguments to pass to session.send().
+            no_cache (optional [boolean]): specifies the use of cache to be True or False. 
 
         Returns:
             (numpy.array): A 3D or 4D numpy matrix in ZXY(time) order.

--- a/intern/service/boss/v1/volume.py
+++ b/intern/service/boss/v1/volume.py
@@ -93,7 +93,7 @@ class VolumeService_1(BaseVersion):
 
     def get_cutout(
             self, resource, resolution, x_range, y_range, z_range, time_range, id_list,
-            url_prefix, auth, session, send_opts, **kwargs
+            url_prefix, auth, session, send_opts, no_cache=False, **kwargs
         ):
         """
         Upload a cutout to the Boss data store.
@@ -157,7 +157,7 @@ class VolumeService_1(BaseVersion):
             resource, 'GET', 'application/blosc',
             url_prefix, auth,
             resolution, x_range, y_range, z_range, time_range,
-            id_list=id_list, **kwargs
+            id_list=id_list, no_cache=no_cache, **kwargs
         )
         prep = session.prepare_request(req)
         # Hack in Accept header for now.

--- a/intern/service/boss/volume.py
+++ b/intern/service/boss/volume.py
@@ -80,7 +80,7 @@ class VolumeService(BossService):
             self.url_prefix, self.auth, self.session, self.session_send_opts)
 
     @check_channel
-    def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[]):
+    def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[], **kwargs):
         """Get a cutout from the volume service.
 
         Args:
@@ -101,7 +101,7 @@ class VolumeService(BossService):
 
         return self.service.get_cutout(
             resource, resolution, x_range, y_range, z_range, time_range, id_list,
-            self.url_prefix, self.auth, self.session, self.session_send_opts)
+            self.url_prefix, self.auth, self.session, self.session_send_opts, **kwargs)
 
     @check_channel
     def reserve_ids(self, resource, num_ids):

--- a/intern/service/boss/volume.py
+++ b/intern/service/boss/volume.py
@@ -91,6 +91,7 @@ class VolumeService(BossService):
             z_range (list[int]): z range such as [10, 20] which means z>=10 and z<20.
             time_range (optional [list[int]]): time range such as [30, 40] which means t>=30 and t<40.
             id_list (optional [list[int]]): list of object ids to filter the cutout by.
+            no_cache (optional [boolean]): specifies the use of cache to be True or False. 
 
         Returns:
             (numpy.array): A 3D or 4D (time) numpy matrix in (time)ZYX order.

--- a/intern/service/boss/volume.py
+++ b/intern/service/boss/volume.py
@@ -80,7 +80,7 @@ class VolumeService(BossService):
             self.url_prefix, self.auth, self.session, self.session_send_opts)
 
     @check_channel
-    def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[], **kwargs):
+    def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[], no_cache=False, **kwargs):
         """Get a cutout from the volume service.
 
         Args:
@@ -101,7 +101,7 @@ class VolumeService(BossService):
 
         return self.service.get_cutout(
             resource, resolution, x_range, y_range, z_range, time_range, id_list,
-            self.url_prefix, self.auth, self.session, self.session_send_opts, **kwargs)
+            self.url_prefix, self.auth, self.session, self.session_send_opts, no_cache, **kwargs)
 
     @check_channel
     def reserve_ids(self, resource, num_ids):


### PR DESCRIPTION
Adds the option to get_cutout without using cache. 
Defaults to no_cache = False. 

Use:
```python
boss = BossRemote()
volume = boss.get_cutout(
    boss.get_channel("chan", "coll", "expp"), 1,
    [10000, 10500], [10000, 10500], [500, 550], no_cache = True,
)
```