### PR TITLE
Fixes no_cache bug

### DIFF
--- a/intern/service/boss/baseversion.py
+++ b/intern/service/boss/baseversion.py
@@ -182,7 +182,7 @@ class BaseVersion(object):
             urlWithParams += '?filter=' + self.convert_int_list_to_comma_sep_str(id_list)
 
         if no_cache:
-            urlWithParams += '?no-cache=true' + '/' 
+            urlWithParams += '?no-cache=true'
 
         return urlWithParams
 


### PR DESCRIPTION
Fixes no_cache bug by removing appended `/` when defining request param. 

It seems the extra `/` leads to the boss comparing `true/` to `true`, and thus does not correctly request `no-cache=True`