### PR TITLE
More unit tests to ensure no_cache defaults True.

### DIFF
--- a/intern/remote/boss/tests/test_remote_get_cutout.py
+++ b/intern/remote/boss/tests/test_remote_get_cutout.py
@@ -1,0 +1,47 @@
+# Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from intern.remote.boss import BossRemote
+from intern.resource.boss.resource import ChannelResource
+from intern.service.boss.volume import VolumeService
+from mock import patch, ANY
+import unittest
+
+
+class TestRemoteGetCutout(unittest.TestCase):
+    def setUp(self):
+        config = {"protocol": "https",
+                  "host": "test.theboss.io",
+                  "token": "my_secret"}
+        self.remote = BossRemote(config)
+
+    @patch.object(VolumeService, 'get_cutout', autospec=True)
+    def test_get_cutout_no_cache_defaults_true(self, fake_volume):
+        """
+        Test that if no_cache not provided, it defaults to True when calling
+        the volume service's get_cutout().
+        """
+        chan = ChannelResource('chan', 'foo', 'bar', 'image', datatype='uint16')
+        resolution = 0
+        x_range = [20, 40]
+        y_range = [50, 70]
+        z_range = [30, 50]
+        self.remote.get_cutout(chan, resolution, x_range, y_range, z_range)
+        fake_volume.assert_called_with(
+            ANY, chan, resolution, x_range, y_range, z_range, ANY, ANY,
+            True)   # This should be the no_cache argument.
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/intern/service/boss/volume.py
+++ b/intern/service/boss/volume.py
@@ -80,7 +80,7 @@ class VolumeService(BossService):
             self.url_prefix, self.auth, self.session, self.session_send_opts)
 
     @check_channel
-    def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[], no_cache=False, **kwargs):
+    def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[], no_cache=True, **kwargs):
         """Get a cutout from the volume service.
 
         Args:


### PR DESCRIPTION
Additional unit tests that test at the BossRemote level and at the VolumeService level. Previous tests tested at VolumeService_1 (the lowest level).