### PR TITLE
Raw no cache mode feature

### DIFF
--- a/intern/remote/boss/remote.py
+++ b/intern/remote/boss/remote.py
@@ -880,7 +880,7 @@ class BossRemote(Remote):
             Raises:
                 requests.HTTPError on error.
             """
-            if no_cache != None:
+            if no_cache is not None:
                 print("\033[93mThe no-cache option has been deprecated and will not be used in future versions of intern.\033[0m")
                 print("\033[93mPlease from intern.service.boss.volume import CacheMode and use access_mode=CacheMode.[cache,no-cache,raw] instead.\033[0m")
             if no_cache and access_mode.value=='no_cache':

--- a/intern/remote/boss/remote.py
+++ b/intern/remote/boss/remote.py
@@ -18,7 +18,7 @@ from intern.resource.boss.resource import *
 from intern.service.boss.project import ProjectService
 from intern.service.boss.metadata import MetadataService
 from intern.service.boss.volume import VolumeService
-from intern.service.boss.baseversion import CacheMode
+from intern.service.boss.v1.volume import CacheMode
 import warnings
 
 

--- a/intern/remote/boss/remote.py
+++ b/intern/remote/boss/remote.py
@@ -19,6 +19,7 @@ from intern.service.boss.project import ProjectService
 from intern.service.boss.metadata import MetadataService
 from intern.service.boss.volume import VolumeService
 from intern.service.boss.volume import CacheMode
+import warnings
 
 
 CONFIG_PROJECT_SECTION = 'Project Service'
@@ -850,7 +851,7 @@ class BossRemote(Remote):
         self.metadata_service.set_auth(self._token_metadata)
         self.metadata_service.delete(resource, keys)
 
-    def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[], access_mode=CacheMode.no_cache, **kwargs):
+    def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[], no_cache=True, access_mode=CacheMode.no_cache, **kwargs):
             """Get a cutout from the volume service.
 
             Note that access_mode=no_cache is desirable when reading large amounts of
@@ -879,5 +880,9 @@ class BossRemote(Remote):
             Raises:
                 requests.HTTPError on error.
             """
-
+            if no_cache:
+                access_mode=CacheMode.no_cache
+            elif not no_cache:
+                access_mode-CacheMode.cache
+            warnings.warn("The no-cache option has been depracted and will not be used in future version of intern. Please use access_mode=raw,cache,no_cache.",DeprecationWarning)
             return self._volume.get_cutout(resource, resolution, x_range, y_range, z_range, time_range, id_list, access_mode, **kwargs)

--- a/intern/remote/boss/remote.py
+++ b/intern/remote/boss/remote.py
@@ -880,9 +880,9 @@ class BossRemote(Remote):
             Raises:
                 requests.HTTPError on error.
             """
-            if no_cache:
+            warnings.warn("The no-cache option has been depracted and will not be used in future version of intern. Please use access_mode=raw,cache,no_cache.",DeprecationWarning)
+            if no_cache and access_mode.value=='no_cache':
                 access_mode=CacheMode.no_cache
             elif not no_cache:
-                access_mode-CacheMode.cache
-            warnings.warn("The no-cache option has been depracted and will not be used in future version of intern. Please use access_mode=raw,cache,no_cache.",DeprecationWarning)
+                access_mode=CacheMode.cache
             return self._volume.get_cutout(resource, resolution, x_range, y_range, z_range, time_range, id_list, access_mode, **kwargs)

--- a/intern/remote/boss/remote.py
+++ b/intern/remote/boss/remote.py
@@ -880,7 +880,8 @@ class BossRemote(Remote):
             Raises:
                 requests.HTTPError on error.
             """
-            warnings.warn("The no-cache option has been depracted and will not be used in future version of intern. Please use access_mode=raw,cache,no_cache.",DeprecationWarning)
+            print("\033[93mThe no-cache option has been depracted and will not be used in future versions of intern.\033[0m")
+            print("\033[93mPlease from intern.service.boss.volume import CacheMode and use access_mode=CacheMode.[cache,no-cache,raw] instead.\033[0m")
             if no_cache and access_mode.value=='no_cache':
                 access_mode=CacheMode.no_cache
             elif not no_cache:

--- a/intern/remote/boss/remote.py
+++ b/intern/remote/boss/remote.py
@@ -881,9 +881,12 @@ class BossRemote(Remote):
                 requests.HTTPError on error.
             """
             if no_cache is not None:
-                print("\033[93mThe no-cache option has been deprecated and will not be used in future versions of intern.\033[0m")
-                print("\033[93mPlease from intern.service.boss.volume import CacheMode and use access_mode=CacheMode.[cache,no-cache,raw] instead.\033[0m")
-            if no_cache and access_mode.value=='no_cache':
+                warnings.warn("The no-cache option has been deprecated and will not be used in future versions of intern.")
+                warnings.warn("Please from intern.service.boss.volume import CacheMode and use access_mode=CacheMode.[cache,no-cache,raw] instead.")
+            if no_cache is not None and access_mode is not None:
+                warning.warn("Both no_cache and access_mode were used, please use access_mode only. As no_cache has been deprecated. ")
+                warning.warn("Your request will be made using the default no_cache option.")    
+            if no_cache:
                 access_mode=CacheMode.no_cache
             elif no_cache == False:
                 access_mode=CacheMode.cache

--- a/intern/remote/boss/remote.py
+++ b/intern/remote/boss/remote.py
@@ -18,7 +18,7 @@ from intern.resource.boss.resource import *
 from intern.service.boss.project import ProjectService
 from intern.service.boss.metadata import MetadataService
 from intern.service.boss.volume import VolumeService
-from intern.service.boss.volume import CacheMode
+from intern.service.boss.baseversion import CacheMode
 import warnings
 
 
@@ -883,9 +883,10 @@ class BossRemote(Remote):
             if no_cache is not None:
                 warnings.warn("The no-cache option has been deprecated and will not be used in future versions of intern.")
                 warnings.warn("Please from intern.service.boss.volume import CacheMode and use access_mode=CacheMode.[cache,no-cache,raw] instead.")
-            if no_cache is not None and access_mode is not None:
-                warning.warn("Both no_cache and access_mode were used, please use access_mode only. As no_cache has been deprecated. ")
-                warning.warn("Your request will be made using the default no_cache option.")    
+            if no_cache and access_mode != "no_cache":
+                warnings.warn("Both no_cache and access_mode were used, please use access_mode only. As no_cache has been deprecated. ")
+                warnings.warn("Your request will be made using the default mode no_cache.")
+                access_mode=CacheMode.no_cache    
             if no_cache:
                 access_mode=CacheMode.no_cache
             elif no_cache == False:

--- a/intern/remote/boss/remote.py
+++ b/intern/remote/boss/remote.py
@@ -30,7 +30,6 @@ CONFIG_TOKEN = 'token'
 
 LATEST_VERSION = 'v1'
 
-
 class BossRemote(Remote):
     """
     Remote provides an SDK to the Boss API.
@@ -850,10 +849,10 @@ class BossRemote(Remote):
         self.metadata_service.set_auth(self._token_metadata)
         self.metadata_service.delete(resource, keys)
 
-    def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[], no_cache=True, **kwargs):
+    def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[], access_mode=CacheMode.no_cache, **kwargs):
             """Get a cutout from the volume service.
 
-            Note that no_cache=True is desirable when reading large amounts of
+            Note that mode=no_cache is desirable when reading large amounts of
             data at once.  In these cases, the data is not first read into the
             cache, but instead, is sent directly from the data store to the
             requester.
@@ -866,7 +865,12 @@ class BossRemote(Remote):
                 z_range (list[int]): z range such as [10, 20] which means z>=10 and z<20.
                 time_range (optional [list[int]]): time range such as [30, 40] which means t>=30 and t<40.
                 id_list (optional [list[int]]): list of object ids to filter the cutout by.
-                no_cache (optional [boolean]): specifies the use of cache to be True or False. 
+                access_mode (optional [Enum]): Identifies one of three cache access options:
+                    cache = Will check both cache and for dirty keys
+                    no_cache = Will skip cache check but check for dirty keys
+                    raw = Will skip both the cache and dirty keys check
+
+                TODO: Add mode to ocumentation
 
             Returns:
                 (numpy.array): A 3D or 4D (time) numpy matrix in (time)ZYX order.
@@ -875,4 +879,4 @@ class BossRemote(Remote):
                 requests.HTTPError on error.
             """
 
-            return self._volume.get_cutout(resource, resolution, x_range, y_range, z_range, time_range, id_list, no_cache, **kwargs)
+            return self._volume.get_cutout(resource, resolution, x_range, y_range, z_range, time_range, id_list, access_mode, **kwargs)

--- a/intern/remote/boss/remote.py
+++ b/intern/remote/boss/remote.py
@@ -883,7 +883,7 @@ class BossRemote(Remote):
             if no_cache is not None:
                 warnings.warn("The no-cache option has been deprecated and will not be used in future versions of intern.")
                 warnings.warn("Please from intern.service.boss.volume import CacheMode and use access_mode=CacheMode.[cache,no-cache,raw] instead.")
-            if no_cache and access_mode != "no_cache":
+            if no_cache and access_mode != CacheMode.no_cache:
                 warnings.warn("Both no_cache and access_mode were used, please use access_mode only. As no_cache has been deprecated. ")
                 warnings.warn("Your request will be made using the default mode no_cache.")
                 access_mode=CacheMode.no_cache    

--- a/intern/remote/boss/remote.py
+++ b/intern/remote/boss/remote.py
@@ -18,6 +18,7 @@ from intern.resource.boss.resource import *
 from intern.service.boss.project import ProjectService
 from intern.service.boss.metadata import MetadataService
 from intern.service.boss.volume import VolumeService
+from intern.service.boss.volume import CacheMode
 
 
 CONFIG_PROJECT_SECTION = 'Project Service'

--- a/intern/remote/boss/remote.py
+++ b/intern/remote/boss/remote.py
@@ -851,7 +851,7 @@ class BossRemote(Remote):
         self.metadata_service.set_auth(self._token_metadata)
         self.metadata_service.delete(resource, keys)
 
-    def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[], no_cache=True, access_mode=CacheMode.no_cache, **kwargs):
+    def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[], no_cache=None, access_mode=CacheMode.no_cache, **kwargs):
             """Get a cutout from the volume service.
 
             Note that access_mode=no_cache is desirable when reading large amounts of
@@ -880,10 +880,11 @@ class BossRemote(Remote):
             Raises:
                 requests.HTTPError on error.
             """
-            print("\033[93mThe no-cache option has been depracted and will not be used in future versions of intern.\033[0m")
-            print("\033[93mPlease from intern.service.boss.volume import CacheMode and use access_mode=CacheMode.[cache,no-cache,raw] instead.\033[0m")
+            if no_cache != None:
+                print("\033[93mThe no-cache option has been deprecated and will not be used in future versions of intern.\033[0m")
+                print("\033[93mPlease from intern.service.boss.volume import CacheMode and use access_mode=CacheMode.[cache,no-cache,raw] instead.\033[0m")
             if no_cache and access_mode.value=='no_cache':
                 access_mode=CacheMode.no_cache
-            elif not no_cache:
+            elif no_cache == False:
                 access_mode=CacheMode.cache
             return self._volume.get_cutout(resource, resolution, x_range, y_range, z_range, time_range, id_list, access_mode, **kwargs)

--- a/intern/remote/boss/remote.py
+++ b/intern/remote/boss/remote.py
@@ -853,7 +853,7 @@ class BossRemote(Remote):
     def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[], access_mode=CacheMode.no_cache, **kwargs):
             """Get a cutout from the volume service.
 
-            Note that mode=no_cache is desirable when reading large amounts of
+            Note that access_mode=no_cache is desirable when reading large amounts of
             data at once.  In these cases, the data is not first read into the
             cache, but instead, is sent directly from the data store to the
             requester.
@@ -871,7 +871,7 @@ class BossRemote(Remote):
                     no_cache = Will skip cache check but check for dirty keys
                     raw = Will skip both the cache and dirty keys check
 
-                TODO: Add mode to ocumentation
+                TODO: Add mode to documentation
 
             Returns:
                 (numpy.array): A 3D or 4D (time) numpy matrix in (time)ZYX order.

--- a/intern/remote/boss/tests/test_remote_get_cutout.py
+++ b/intern/remote/boss/tests/test_remote_get_cutout.py
@@ -1,0 +1,112 @@
+# Copyright 2018 The Johns Hopkins University Applied Physics Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from intern.remote.boss import BossRemote
+from intern.resource.boss.resource import ChannelResource
+from intern.service.boss.volume import VolumeService
+from intern.service.boss.v1.volume import CacheMode
+from mock import patch, ANY
+import unittest
+
+
+class TestRemoteGetCutout(unittest.TestCase):
+    def setUp(self):
+        config = {"protocol": "https",
+                  "host": "test.theboss.io",
+                  "token": "my_secret"}
+        self.remote = BossRemote(config)
+
+    @patch.object(VolumeService, 'get_cutout', autospec=True)
+    def test_get_cutout_access_mode_defaults_no_cache(self, fake_volume):
+        """
+        Test that if no_cache not provided, it defaults to True when calling
+        the volume service's get_cutout().
+        """
+        chan = ChannelResource('chan', 'foo', 'bar', 'image', datatype='uint16')
+        resolution = 0
+        x_range = [20, 40]
+        y_range = [50, 70]
+        z_range = [30, 50]
+        self.remote.get_cutout(chan, resolution, x_range, y_range, z_range)
+        fake_volume.assert_called_with(
+            ANY, chan, resolution, x_range, y_range, z_range, ANY, ANY,
+            CacheMode.no_cache)   # This should be the no_cache argument.
+
+    @patch.object(VolumeService, 'get_cutout', autospec=True)
+    def test_get_cutout_access_mode_raw(self, fake_volume):
+        """
+        Test that if no_cache not provided, it defaults to True when calling
+        the volume service's get_cutout().
+        """
+        chan = ChannelResource('chan', 'foo', 'bar', 'image', datatype='uint16')
+        resolution = 0
+        x_range = [20, 40]
+        y_range = [50, 70]
+        z_range = [30, 50]
+        self.remote.get_cutout(chan, resolution, x_range, y_range, z_range, access_mode=CacheMode.raw)
+        fake_volume.assert_called_with(
+            ANY, chan, resolution, x_range, y_range, z_range, ANY, ANY,
+            CacheMode.raw)   # This should be the no_cache argument.
+
+    @patch.object(VolumeService, 'get_cutout', autospec=True)
+    def test_get_cutout_access_mode_cache(self, fake_volume):
+        """
+        Test that if no_cache not provided, it defaults to True when calling
+        the volume service's get_cutout().
+        """
+        chan = ChannelResource('chan', 'foo', 'bar', 'image', datatype='uint16')
+        resolution = 0
+        x_range = [20, 40]
+        y_range = [50, 70]
+        z_range = [30, 50]
+        self.remote.get_cutout(chan, resolution, x_range, y_range, z_range, access_mode=CacheMode.cache)
+        fake_volume.assert_called_with(
+            ANY, chan, resolution, x_range, y_range, z_range, ANY, ANY,
+            CacheMode.cache)   # This should be the no_cache argument.
+
+    
+    ##REMOVE IN THE FUTURE, TESTS BACKWARDS COMPATABILITY
+    @patch.object(VolumeService, 'get_cutout', autospec=True)
+    def test_get_cutout_no_cache_True_backwards_compatability(self, fake_volume):
+        """
+        Test that if no_cache not provided, it defaults to True when calling
+        the volume service's get_cutout().
+        """
+        chan = ChannelResource('chan', 'foo', 'bar', 'image', datatype='uint16')
+        resolution = 0
+        x_range = [20, 40]
+        y_range = [50, 70]
+        z_range = [30, 50]
+        self.remote.get_cutout(chan, resolution, x_range, y_range, z_range, no_cache=True)
+        fake_volume.assert_called_with(
+            ANY, chan, resolution, x_range, y_range, z_range, ANY, ANY,
+            CacheMode.no_cache)   # This should be the no_cache argument.
+
+    @patch.object(VolumeService, 'get_cutout', autospec=True)
+    def test_get_cutout_no_cache_False_backwards_compatability(self, fake_volume):
+        """
+        Test that if no_cache not provided, it defaults to True when calling
+        the volume service's get_cutout().
+        """
+        chan = ChannelResource('chan', 'foo', 'bar', 'image', datatype='uint16')
+        resolution = 0
+        x_range = [20, 40]
+        y_range = [50, 70]
+        z_range = [30, 50]
+        self.remote.get_cutout(chan, resolution, x_range, y_range, z_range, no_cache=False)
+        fake_volume.assert_called_with(
+            ANY, chan, resolution, x_range, y_range, z_range, ANY, ANY,
+            CacheMode.cache)   # This should be the no_cache argument.
+if __name__ == '__main__':
+    unittest.main()

--- a/intern/resource/boss/resource.py
+++ b/intern/resource/boss/resource.py
@@ -14,7 +14,12 @@
 
 from intern.resource import Resource
 from abc import abstractmethod
+from enum import Enum
 
+class CacheMode(Enum):
+    cache = 'cache'
+    no_cache = 'no_cache'
+    raw = 'raw'
 
 class BossResource(Resource):
     """Base class for Boss resources.

--- a/intern/resource/boss/resource.py
+++ b/intern/resource/boss/resource.py
@@ -14,12 +14,6 @@
 
 from intern.resource import Resource
 from abc import abstractmethod
-from enum import Enum
-
-class CacheMode(Enum):
-    cache = 'cache'
-    no_cache = 'no_cache'
-    raw = 'raw'
 
 class BossResource(Resource):
     """Base class for Boss resources.

--- a/intern/service/boss/baseversion.py
+++ b/intern/service/boss/baseversion.py
@@ -14,7 +14,7 @@
 import six
 from abc import ABCMeta, abstractmethod
 from intern.resource.boss.resource import CoordinateFrameResource
-from intern.resource.boss.resource import CacheMode
+from intern.service.boss.volume import CacheMode
 from requests import Request
 
 

--- a/intern/service/boss/baseversion.py
+++ b/intern/service/boss/baseversion.py
@@ -15,7 +15,12 @@ import six
 from abc import ABCMeta, abstractmethod
 from intern.resource.boss.resource import CoordinateFrameResource
 from requests import Request
+from enum import Enum
 
+class CacheMode(str, Enum):
+    cache = 'cache'
+    no_cache = 'no_cache'
+    raw = 'raw'
 
 @six.add_metaclass(ABCMeta)
 class BaseVersion(object):
@@ -147,7 +152,7 @@ class BaseVersion(object):
         return urlWithKey + '&value=' + str(value)
 
     def build_cutout_url(
-        self, resource, url_prefix, resolution, x_range, y_range, z_range,  access_mode, time_range=None, id_list=[]):
+        self, resource, url_prefix, resolution, x_range, y_range, z_range,  access_mode=CacheMode.no_cache, time_range=None, id_list=[]):
         """Build the url to access the cutout function of the Boss' volume service.
 
         Args:
@@ -261,7 +266,7 @@ class BaseVersion(object):
 
     def get_cutout_request(
         self, resource, method, content, url_prefix, token,
-        resolution, x_range, y_range, z_range, time_range, access_mode, numpyVolume=None, id_list=[]):
+        resolution, x_range, y_range, z_range, time_range, access_mode=CacheMode.no_cache, numpyVolume=None, id_list=[]):
 
         """Create a request for working with cutouts (part of the Boss' volume service).
 

--- a/intern/service/boss/baseversion.py
+++ b/intern/service/boss/baseversion.py
@@ -14,7 +14,6 @@
 import six
 from abc import ABCMeta, abstractmethod
 from intern.resource.boss.resource import CoordinateFrameResource
-from intern.service.boss.volume import CacheMode
 from requests import Request
 
 
@@ -148,7 +147,7 @@ class BaseVersion(object):
         return urlWithKey + '&value=' + str(value)
 
     def build_cutout_url(
-        self, resource, url_prefix, resolution, x_range, y_range, z_range,  time_range=None, id_list=[], access_mode=CacheMode.no_cache):
+        self, resource, url_prefix, resolution, x_range, y_range, z_range,  access_mode, time_range=None, id_list=[]):
         """Build the url to access the cutout function of the Boss' volume service.
 
         Args:
@@ -186,9 +185,9 @@ class BaseVersion(object):
         if len(id_list) > 0:
             urlWithParams += '?filter=' + self.convert_int_list_to_comma_sep_str(id_list)
 
-        if access_mode.value == 'no_cache':
+        if access_mode == 'no_cache':
             urlWithParams += '?access_mode=no-cache'
-        elif access_mode.value == 'raw'"
+        elif access_mode == 'raw':
             urlWithParams += '?access_mode=raw'
         else:
             urlWithParams += '?access_mode=cache'
@@ -262,7 +261,7 @@ class BaseVersion(object):
 
     def get_cutout_request(
         self, resource, method, content, url_prefix, token,
-        resolution, x_range, y_range, z_range, time_range, numpyVolume=None, id_list=[], access_mode=CacheMode.no_cache):
+        resolution, x_range, y_range, z_range, time_range, access_mode, numpyVolume=None, id_list=[]):
 
         """Create a request for working with cutouts (part of the Boss' volume service).
 
@@ -291,7 +290,7 @@ class BaseVersion(object):
             RuntimeError if url_prefix is None or an empty string.
         """
         url = self.build_cutout_url(
-            resource, url_prefix, resolution, x_range, y_range, z_range, time_range,  id_list, access_mode)
+            resource, url_prefix, resolution, x_range, y_range, z_range, access_mode, time_range, id_list)
         headers = self.get_headers(content, token)
         return Request(method, url, headers = headers, data = numpyVolume)
 

--- a/intern/service/boss/baseversion.py
+++ b/intern/service/boss/baseversion.py
@@ -15,12 +15,7 @@ import six
 from abc import ABCMeta, abstractmethod
 from intern.resource.boss.resource import CoordinateFrameResource
 from requests import Request
-from enum import Enum
-
-class CacheMode(str, Enum):
-    cache = 'cache'
-    no_cache = 'no-cache'
-    raw = 'raw'
+import urllib
 
 @six.add_metaclass(ABCMeta)
 class BaseVersion(object):
@@ -152,7 +147,7 @@ class BaseVersion(object):
         return urlWithKey + '&value=' + str(value)
 
     def build_cutout_url(
-        self, resource, url_prefix, resolution, x_range, y_range, z_range,  access_mode=CacheMode.no_cache, time_range=None, id_list=[]):
+        self, resource, url_prefix, resolution, x_range, y_range, z_range, time_range=None, id_list=[], access_mode=None):
         """Build the url to access the cutout function of the Boss' volume service.
 
         Args:
@@ -167,6 +162,7 @@ class BaseVersion(object):
                 cache = Will check both cache and for dirty keys
                 no_cache = Will skip cache check but check for dirty keys
                 raw = Will skip both the cache and dirty keys check
+                NOTE: No default here since when building a cutout url to create_cutout there is no need for access_mode
 
         Returns:
             (string): Full URL to access API.
@@ -187,12 +183,15 @@ class BaseVersion(object):
             t_rng_lst = self.convert_int_list_range_to_str(time_range)
             urlWithParams += t_rng_lst + '/'
 
+        queryParamDict = {}
         if len(id_list) > 0:
-            urlWithParams += '?filter=' + self.convert_int_list_to_comma_sep_str(id_list)
-
-        # Add the access_mode parameter
-        urlWithParams += '?access-mode={}'.format(access_mode)
-
+            queryParamDict['filter'] = self.convert_int_list_to_comma_sep_str(id_list)
+    
+        # If creating a cutout, the url will not include the access_mode otherwise it will
+        if access_mode is not None:
+            queryParamDict['access-mode'] = access_mode.value 
+        if queryParamDict:
+            urlWithParams += '?' + urllib.parse.urlencode(queryParamDict,safe=",")
         return urlWithParams
 
     def get_request(self, resource, method, content, url_prefix, token, proj_list_req=False, json=None, data=None):
@@ -262,7 +261,7 @@ class BaseVersion(object):
 
     def get_cutout_request(
         self, resource, method, content, url_prefix, token,
-        resolution, x_range, y_range, z_range, time_range, access_mode=CacheMode.no_cache, numpyVolume=None, id_list=[]):
+        resolution, x_range, y_range, z_range, time_range,  numpyVolume=None, id_list=[], access_mode=None,):
 
         """Create a request for working with cutouts (part of the Boss' volume service).
 
@@ -291,7 +290,7 @@ class BaseVersion(object):
             RuntimeError if url_prefix is None or an empty string.
         """
         url = self.build_cutout_url(
-            resource, url_prefix, resolution, x_range, y_range, z_range, access_mode, time_range, id_list)
+            resource, url_prefix, resolution, x_range, y_range, z_range,  time_range, id_list, access_mode)
         headers = self.get_headers(content, token)
         return Request(method, url, headers = headers, data = numpyVolume)
 

--- a/intern/service/boss/baseversion.py
+++ b/intern/service/boss/baseversion.py
@@ -186,11 +186,11 @@ class BaseVersion(object):
             urlWithParams += '?filter=' + self.convert_int_list_to_comma_sep_str(id_list)
 
         if access_mode == 'no_cache':
-            urlWithParams += '?access_mode=no-cache'
+            urlWithParams += '?access-mode=no-cache'
         elif access_mode == 'raw':
-            urlWithParams += '?access_mode=raw'
+            urlWithParams += '?access-mode=raw'
         else:
-            urlWithParams += '?access_mode=cache'
+            urlWithParams += '?access-mode=cache'
 
         return urlWithParams
 

--- a/intern/service/boss/baseversion.py
+++ b/intern/service/boss/baseversion.py
@@ -19,7 +19,7 @@ from enum import Enum
 
 class CacheMode(str, Enum):
     cache = 'cache'
-    no_cache = 'no_cache'
+    no_cache = 'no-cache'
     raw = 'raw'
 
 @six.add_metaclass(ABCMeta)
@@ -190,12 +190,8 @@ class BaseVersion(object):
         if len(id_list) > 0:
             urlWithParams += '?filter=' + self.convert_int_list_to_comma_sep_str(id_list)
 
-        if access_mode == 'no_cache':
-            urlWithParams += '?access-mode=no-cache'
-        elif access_mode == 'raw':
-            urlWithParams += '?access-mode=raw'
-        else:
-            urlWithParams += '?access-mode=cache'
+        # Add the access_mode parameter
+        urlWithParams += '?access-mode={}'.format(access_mode)
 
         return urlWithParams
 

--- a/intern/service/boss/tests/test_baseversion.py
+++ b/intern/service/boss/tests/test_baseversion.py
@@ -14,6 +14,7 @@
 
 import unittest
 from intern.service.boss.baseversion import BaseVersion
+from intern.service.boss.v1.volume import CacheMode
 from intern.resource.boss.resource import CollectionResource
 from intern.resource.boss.resource import ChannelResource
 import numpy
@@ -478,6 +479,35 @@ class BaseVersionTest(unittest.TestCase):
             resolution, x_rng_lst, y_rng_lst, z_rng_lst, t_rng_lst, id_list=id_list)
         self.assertEqual(
             '{}/{}/{}/{}/{}/{}/{}/{}/{}/{}/{}/?filter={}'.format(url_prefix, self.test_volume.version,
+            self.test_volume.endpoint, self.chanResource.coll_name,
+            self.chanResource.exp_name, self.chanResource.name, resolution,
+            x_range, y_range, z_range, time_range, id_list_str),
+            actual.url)
+        self.assertEqual('Token {}'.format(token), actual.headers['Authorization'])
+        self.assertEqual('application/blosc-python', actual.headers['Content-Type'])
+
+    def test_get_cutout_request_with_ids_and_access_mode(self):
+        """Test request generated for a filtered cutout."""
+        url_prefix = 'https://api.theboss.io'
+        token = 'foobar'
+        resolution = 0
+        x_rng_lst = [20, 40]
+        x_range = '20:40'
+        y_rng_lst = [50, 70]
+        y_range = '50:70'
+        z_rng_lst = [30, 50]
+        z_range = '30:50'
+        t_rng_lst = [10, 25]
+        time_range = '10:25'
+        id_list = [10, 5]
+        id_list_str = '10,5'
+        data = numpy.random.randint(0, 3000, (15, 20, 20, 20), numpy.uint16)
+
+        actual = self.test_volume.get_cutout_request(
+            self.chanResource, 'GET', 'application/blosc-python', url_prefix, token,
+            resolution, x_rng_lst, y_rng_lst, z_rng_lst, t_rng_lst, id_list=id_list, access_mode=CacheMode.no_cache)
+        self.assertEqual(
+            '{}/{}/{}/{}/{}/{}/{}/{}/{}/{}/{}/?filter={}&access-mode=no-cache'.format(url_prefix, self.test_volume.version,
             self.test_volume.endpoint, self.chanResource.coll_name,
             self.chanResource.exp_name, self.chanResource.name, resolution,
             x_range, y_range, z_range, time_range, id_list_str),

--- a/intern/service/boss/v1/tests/test_volume.py
+++ b/intern/service/boss/v1/tests/test_volume.py
@@ -14,6 +14,7 @@
 
 from intern.service.boss.v1.volume import VolumeService_1
 from intern.service.boss import BaseVersion
+from intern.service.boss.v1.volume import CacheMode
 from intern.resource.boss.resource import ChannelResource
 import blosc
 import numpy
@@ -125,7 +126,7 @@ class TestVolume_v1(unittest.TestCase):
                 url_prefix, auth, mock_session, send_opts)
 
     @patch('requests.Session', autospec=True)
-    def test_get_cutout_no_cache_defaults_true_small_cutout(self, mock_session):
+    def test_get_cutout_access_mode_defaults_no_cache_small_cutout(self, mock_session):
         """Ensure no-cache defaults to True."""
         resolution = 0
         x_range = [20, 40]
@@ -152,11 +153,11 @@ class TestVolume_v1(unittest.TestCase):
             self.vol.get_cutout(self.chan, resolution, x_range, y_range, z_range, 
                 time_range, id_list, url_prefix, auth, mock_session, send_opts)
             req_spy.assert_called_with(ANY, ANY, 'GET', ANY, url_prefix, auth, resolution,
-                x_range, y_range, z_range, time_range, id_list=[], no_cache=True)
+                x_range, y_range, z_range, time_range, id_list=[], access_mode=CacheMode.no_cache)
             self.assertEqual(1, req_spy.call_count)
 
     @patch('requests.Session', autospec=True)
-    def test_get_cutout_no_cache_defaults_true_large_cutout(self, mock_session):
+    def test_get_cutout_access_mode_defaults_no_cache_large_cutout(self, mock_session):
         """Ensure no-cache defaults to True for all recursive calls generated
         by get_cutout."""
         resolution = 0
@@ -184,9 +185,133 @@ class TestVolume_v1(unittest.TestCase):
             self.vol.get_cutout(self.chan, resolution, x_range, y_range, z_range, 
                 time_range, id_list, url_prefix, auth, mock_session, send_opts)
             req_spy.assert_called_with(ANY, ANY, 'GET', ANY, url_prefix, auth, resolution,
-                ANY, ANY, ANY, ANY, id_list=[], no_cache=True)
+                ANY, ANY, ANY, ANY, id_list=[], access_mode=CacheMode.no_cache)
             # Verify that chunking occured.
             self.assertTrue(req_spy.call_count > 0)
+
+    @patch('requests.Session', autospec=True)
+    def test_get_cutout_access_mode_raw_small_cutout(self, mock_session):
+        """Ensure no-cache defaults to True."""
+        resolution = 0
+        x_range = [20, 40]
+        y_range = [50, 70]
+        z_range = [30, 50]
+        time_range = [10, 25]
+        url_prefix = 'https://api.theboss.io'
+        auth = 'mytoken'
+        id_list = []
+
+        mock_session.prepare_request.return_value = PreparedRequest()
+        mock_session.prepare_request.return_value.headers = {}
+
+        fake_response = Response()
+        fake_response.status_code = 200
+        data = numpy.random.randint(0, 3000, (15, 20, 20, 20), numpy.uint16)
+        compressed_data = blosc.compress(data, typesize=16)
+        fake_response._content = compressed_data
+        mock_session.send.return_value = fake_response
+        send_opts = {}
+
+        with patch.object(
+                BaseVersion, 'get_cutout_request', autospec=True, wraps=BaseVersion.get_cutout_request) as req_spy:
+            self.vol.get_cutout(self.chan, resolution, x_range, y_range, z_range, 
+                time_range, id_list, url_prefix, auth, mock_session, send_opts, access_mode=CacheMode.raw)
+            req_spy.assert_called_with(ANY, ANY, 'GET', ANY, url_prefix, auth, resolution,
+                x_range, y_range, z_range, time_range, id_list=[], access_mode=CacheMode.raw)
+            self.assertEqual(1, req_spy.call_count)
+
+    @patch('requests.Session', autospec=True)
+    def test_get_cutout_access_mode_raw_large_cutout(self, mock_session):
+        """Ensure no-cache defaults to True."""
+        resolution = 0
+        x_range = [20, 1045]
+        y_range = [50, 1075]
+        z_range = [30, 33]
+        time_range = [10, 11]
+        url_prefix = 'https://api.theboss.io'
+        auth = 'mytoken'
+        id_list = []
+
+        mock_session.prepare_request.return_value = PreparedRequest()
+        mock_session.prepare_request.return_value.headers = {}
+
+        fake_response = Response()
+        fake_response.status_code = 200
+        data = numpy.random.randint(0, 3000, (1, 3, 1025, 1025), numpy.uint16)
+        compressed_data = blosc.compress(data, typesize=16)
+        fake_response._content = compressed_data
+        mock_session.send.return_value = fake_response
+        send_opts = {}
+
+        with patch.object(
+                BaseVersion, 'get_cutout_request', autospec=True, wraps=BaseVersion.get_cutout_request) as req_spy:
+            self.vol.get_cutout(self.chan, resolution, x_range, y_range, z_range, 
+                time_range, id_list, url_prefix, auth, mock_session, send_opts, access_mode=CacheMode.raw)
+            req_spy.assert_called_with(ANY, ANY, 'GET', ANY, url_prefix, auth, resolution,
+                x_range, y_range, z_range, time_range, id_list=[], access_mode=CacheMode.raw)
+            self.assertEqual(1, req_spy.call_count)
+
+    @patch('requests.Session', autospec=True)
+    def test_get_cutout_access_mode_raw_small_cutout(self, mock_session):
+        """Ensure no-cache defaults to True."""
+        resolution = 0
+        x_range = [20, 40]
+        y_range = [50, 70]
+        z_range = [30, 50]
+        time_range = [10, 25]
+        url_prefix = 'https://api.theboss.io'
+        auth = 'mytoken'
+        id_list = []
+
+        mock_session.prepare_request.return_value = PreparedRequest()
+        mock_session.prepare_request.return_value.headers = {}
+
+        fake_response = Response()
+        fake_response.status_code = 200
+        data = numpy.random.randint(0, 3000, (15, 20, 20, 20), numpy.uint16)
+        compressed_data = blosc.compress(data, typesize=16)
+        fake_response._content = compressed_data
+        mock_session.send.return_value = fake_response
+        send_opts = {}
+
+        with patch.object(
+                BaseVersion, 'get_cutout_request', autospec=True, wraps=BaseVersion.get_cutout_request) as req_spy:
+            self.vol.get_cutout(self.chan, resolution, x_range, y_range, z_range, 
+                time_range, id_list, url_prefix, auth, mock_session, send_opts, access_mode=CacheMode.cache)
+            req_spy.assert_called_with(ANY, ANY, 'GET', ANY, url_prefix, auth, resolution,
+                x_range, y_range, z_range, time_range, id_list=[], access_mode=CacheMode.cache)
+            self.assertEqual(1, req_spy.call_count)
+
+    @patch('requests.Session', autospec=True)
+    def test_get_cutout_access_mode_cache_large_cutout(self, mock_session):
+        """Ensure no-cache defaults to True."""
+        resolution = 0
+        x_range = [20, 1045]
+        y_range = [50, 1075]
+        z_range = [30, 33]
+        time_range = [10, 11]
+        url_prefix = 'https://api.theboss.io'
+        auth = 'mytoken'
+        id_list = []
+
+        mock_session.prepare_request.return_value = PreparedRequest()
+        mock_session.prepare_request.return_value.headers = {}
+
+        fake_response = Response()
+        fake_response.status_code = 200
+        data = numpy.random.randint(0, 3000, (1, 3, 1025, 1025), numpy.uint16)
+        compressed_data = blosc.compress(data, typesize=16)
+        fake_response._content = compressed_data
+        mock_session.send.return_value = fake_response
+        send_opts = {}
+
+        with patch.object(
+                BaseVersion, 'get_cutout_request', autospec=True, wraps=BaseVersion.get_cutout_request) as req_spy:
+            self.vol.get_cutout(self.chan, resolution, x_range, y_range, z_range, 
+                time_range, id_list, url_prefix, auth, mock_session, send_opts, access_mode=CacheMode.cache)
+            req_spy.assert_called_with(ANY, ANY, 'GET', ANY, url_prefix, auth, resolution,
+                x_range, y_range, z_range, time_range, id_list=[], access_mode=CacheMode.cache)
+            self.assertEqual(1, req_spy.call_count)
 
     @patch('requests.Response', autospec=True)
     @patch('requests.Session', autospec=True)

--- a/intern/service/boss/v1/volume.py
+++ b/intern/service/boss/v1/volume.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from intern.service.boss import BaseVersion
 from intern.service.boss.v1 import BOSS_API_VERSION
+from intern.service.boss.volume import CacheMode
 from intern.resource.boss.resource import *
 from intern.utils.parallel import *
 from intern.utils.

--- a/intern/service/boss/v1/volume.py
+++ b/intern/service/boss/v1/volume.py
@@ -15,11 +15,15 @@ from intern.service.boss import BaseVersion
 from intern.service.boss.v1 import BOSS_API_VERSION
 from intern.resource.boss.resource import *
 from intern.utils.parallel import *
-from intern.service.boss.baseversion import CacheMode
 from requests import HTTPError
 import blosc
 import numpy as np
+from enum import Enum
 
+class CacheMode(str, Enum):
+    cache = 'cache'
+    no_cache = 'no-cache'
+    raw = 'raw'
 
 class VolumeService_1(BaseVersion):
     def __init__(self):
@@ -162,7 +166,7 @@ class VolumeService_1(BaseVersion):
         req = self.get_cutout_request(
             resource, 'GET', 'application/blosc',
             url_prefix, auth,
-            resolution, x_range, y_range, z_range, time_range, access_mode,
+            resolution, x_range, y_range, z_range, time_range, access_mode=access_mode,
             id_list=id_list, **kwargs
         )
         prep = session.prepare_request(req)

--- a/intern/service/boss/v1/volume.py
+++ b/intern/service/boss/v1/volume.py
@@ -15,6 +15,7 @@ from intern.service.boss import BaseVersion
 from intern.service.boss.v1 import BOSS_API_VERSION
 from intern.resource.boss.resource import *
 from intern.utils.parallel import *
+from intern.service.boss.baseversion import CacheMode
 from requests import HTTPError
 import blosc
 import numpy as np
@@ -93,7 +94,7 @@ class VolumeService_1(BaseVersion):
 
     def get_cutout(
             self, resource, resolution, x_range, y_range, z_range, time_range, id_list,
-            url_prefix, auth, session, send_opts, access_mode, **kwargs
+            url_prefix, auth, session, send_opts, access_mode=CacheMode.no_cache, **kwargs
         ):
         """
         Upload a cutout to the Boss data store.

--- a/intern/service/boss/v1/volume.py
+++ b/intern/service/boss/v1/volume.py
@@ -15,6 +15,7 @@ from intern.service.boss import BaseVersion
 from intern.service.boss.v1 import BOSS_API_VERSION
 from intern.resource.boss.resource import *
 from intern.utils.parallel import *
+from intern.utils.
 from requests import HTTPError
 import blosc
 import numpy as np
@@ -93,7 +94,7 @@ class VolumeService_1(BaseVersion):
 
     def get_cutout(
             self, resource, resolution, x_range, y_range, z_range, time_range, id_list,
-            url_prefix, auth, session, send_opts, no_cache=True, **kwargs
+            url_prefix, auth, session, send_opts, access_mode=CacheMode.no_cache, **kwargs
         ):
         """
         Upload a cutout to the Boss data store.
@@ -111,7 +112,10 @@ class VolumeService_1(BaseVersion):
             auth (string): Token to send in the request header.
             session (requests.Session): HTTP session to use for request.
             send_opts (dictionary): Additional arguments to pass to session.send().
-            no_cache (optional [boolean]): specifies the use of cache to be True or False. 
+            access_mode (optional [Enum]): Identifies one of three cache access options:
+                cache = Will check both cache and for dirty keys
+                no_cache = Will skip cache check but check for dirty keys
+                raw = Will skip both the cache and dirty keys check
 
         Returns:
             (numpy.array): A 3D or 4D numpy matrix in ZXY(time) order.
@@ -144,7 +148,7 @@ class VolumeService_1(BaseVersion):
                 _data = self.get_cutout(
                     resource, resolution, b[0], b[1], b[2],
                     time_range, id_list, url_prefix, auth, session, send_opts, 
-                    no_cache, **kwargs
+                    access_mode, **kwargs
                 )
 
                 result[
@@ -159,7 +163,7 @@ class VolumeService_1(BaseVersion):
             resource, 'GET', 'application/blosc',
             url_prefix, auth,
             resolution, x_range, y_range, z_range, time_range,
-            id_list=id_list, no_cache=no_cache, **kwargs
+            id_list=id_list, access_mode.value, **kwargs
         )
         prep = session.prepare_request(req)
         # Hack in Accept header for now.

--- a/intern/service/boss/v1/volume.py
+++ b/intern/service/boss/v1/volume.py
@@ -13,10 +13,8 @@
 # limitations under the License.
 from intern.service.boss import BaseVersion
 from intern.service.boss.v1 import BOSS_API_VERSION
-from intern.service.boss.volume import CacheMode
 from intern.resource.boss.resource import *
 from intern.utils.parallel import *
-from intern.utils.
 from requests import HTTPError
 import blosc
 import numpy as np
@@ -95,7 +93,7 @@ class VolumeService_1(BaseVersion):
 
     def get_cutout(
             self, resource, resolution, x_range, y_range, z_range, time_range, id_list,
-            url_prefix, auth, session, send_opts, access_mode=CacheMode.no_cache, **kwargs
+            url_prefix, auth, session, send_opts, access_mode, **kwargs
         ):
         """
         Upload a cutout to the Boss data store.
@@ -163,8 +161,8 @@ class VolumeService_1(BaseVersion):
         req = self.get_cutout_request(
             resource, 'GET', 'application/blosc',
             url_prefix, auth,
-            resolution, x_range, y_range, z_range, time_range,
-            id_list=id_list, access_mode.value, **kwargs
+            resolution, x_range, y_range, z_range, time_range, access_mode.value,
+            id_list=id_list, **kwargs
         )
         prep = session.prepare_request(req)
         # Hack in Accept header for now.

--- a/intern/service/boss/v1/volume.py
+++ b/intern/service/boss/v1/volume.py
@@ -162,7 +162,7 @@ class VolumeService_1(BaseVersion):
         req = self.get_cutout_request(
             resource, 'GET', 'application/blosc',
             url_prefix, auth,
-            resolution, x_range, y_range, z_range, time_range, access_mode.value,
+            resolution, x_range, y_range, z_range, time_range, access_mode,
             id_list=id_list, **kwargs
         )
         prep = session.prepare_request(req)

--- a/intern/service/boss/volume.py
+++ b/intern/service/boss/volume.py
@@ -15,7 +15,7 @@
 from intern.resource.boss import ChannelResource, PartialChannelResourceError
 from intern.service.boss import BossService
 from intern.service.boss.v1.volume import VolumeService_1
-from intern.service.boss.baseversion import CacheMode
+from intern.service.boss.v1.volume import CacheMode
 
 def check_channel(fcn):
     """Decorator that ensures a valid channel passed in.

--- a/intern/service/boss/volume.py
+++ b/intern/service/boss/volume.py
@@ -13,9 +13,14 @@
 # limitations under the License.
 
 from intern.resource.boss import ChannelResource, PartialChannelResourceError
-from intern.resource.boss.resource import CacheMode
 from intern.service.boss import BossService
 from intern.service.boss.v1.volume import VolumeService_1
+from enum import Enum
+
+class CacheMode(Enum):
+    cache = 'cache'
+    no_cache = 'no_cache'
+    raw = 'raw'
 
 def check_channel(fcn):
     """Decorator that ensures a valid channel passed in.

--- a/intern/service/boss/volume.py
+++ b/intern/service/boss/volume.py
@@ -86,7 +86,7 @@ class VolumeService(BossService):
             self.url_prefix, self.auth, self.session, self.session_send_opts)
 
     @check_channel
-    def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[], mode=CacheMode.no_cache, **kwargs):
+    def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[], access_mode=CacheMode.no_cache, **kwargs):
         """Get a cutout from the volume service.
 
         Args:
@@ -112,7 +112,7 @@ class VolumeService(BossService):
 
         return self.service.get_cutout(
             resource, resolution, x_range, y_range, z_range, time_range, id_list,
-            self.url_prefix, self.auth, self.session, self.session_send_opts, mode, **kwargs)
+            self.url_prefix, self.auth, self.session, self.session_send_opts, access_mode, **kwargs)
 
     @check_channel
     def reserve_ids(self, resource, num_ids):

--- a/intern/service/boss/volume.py
+++ b/intern/service/boss/volume.py
@@ -15,12 +15,7 @@
 from intern.resource.boss import ChannelResource, PartialChannelResourceError
 from intern.service.boss import BossService
 from intern.service.boss.v1.volume import VolumeService_1
-from enum import Enum
-
-class CacheMode(str, Enum):
-    cache = 'cache'
-    no_cache = 'no_cache'
-    raw = 'raw'
+from intern.service.boss.baseversion import CacheMode
 
 def check_channel(fcn):
     """Decorator that ensures a valid channel passed in.

--- a/intern/service/boss/volume.py
+++ b/intern/service/boss/volume.py
@@ -17,7 +17,7 @@ from intern.service.boss import BossService
 from intern.service.boss.v1.volume import VolumeService_1
 from enum import Enum
 
-class CacheMode(Enum):
+class CacheMode(str, Enum):
     cache = 'cache'
     no_cache = 'no_cache'
     raw = 'raw'

--- a/intern/service/boss/volume.py
+++ b/intern/service/boss/volume.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from intern.resource.boss import ChannelResource, PartialChannelResourceError
+from intern.resource.boss.resource import CacheMode
 from intern.service.boss import BossService
 from intern.service.boss.v1.volume import VolumeService_1
 
@@ -80,7 +81,7 @@ class VolumeService(BossService):
             self.url_prefix, self.auth, self.session, self.session_send_opts)
 
     @check_channel
-    def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[], no_cache=False, **kwargs):
+    def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[], mode=CacheMode.no_cache, **kwargs):
         """Get a cutout from the volume service.
 
         Args:
@@ -92,6 +93,10 @@ class VolumeService(BossService):
             time_range (optional [list[int]]): time range such as [30, 40] which means t>=30 and t<40.
             id_list (optional [list[int]]): list of object ids to filter the cutout by.
             no_cache (optional [boolean]): specifies the use of cache to be True or False. 
+            access_mode (optional [Enum]): Identifies one of three cache access options:
+                cache = Will check both cache and for dirty keys
+                no_cache = Will skip cache check but check for dirty keys
+                raw = Will skip both the cache and dirty keys check
 
         Returns:
             (numpy.array): A 3D or 4D (time) numpy matrix in (time)ZYX order.
@@ -102,7 +107,7 @@ class VolumeService(BossService):
 
         return self.service.get_cutout(
             resource, resolution, x_range, y_range, z_range, time_range, id_list,
-            self.url_prefix, self.auth, self.session, self.session_send_opts, no_cache, **kwargs)
+            self.url_prefix, self.auth, self.session, self.session_send_opts, mode, **kwargs)
 
     @check_channel
     def reserve_ids(self, resource, num_ids):


### PR DESCRIPTION
This PR updates intern to correctly make requests specifying an `access_mode` due to the changes in jhuapl-boss/spdb#9 .

Updates:
- `intern` incorporates the `access_mode` parameter when grabbing cutouts of  small AND large sizes. 
- Backwards compatibility with previous versions that make use of the `no_cache` boolean parameter. 
   - Whenever a user makes use of the `no_cache` param intern will return a deprecation warning..=
   -The translation occurs in intern/remote/boss/remote.py and should be removed in future major version upgrades. 
- `intern` uses the an enum class to limit the possibility of cache modes. 

An example of how to use the new `access_mode` param is below:
```python
# BOSS Data fetch:
boss = BossRemote({
    "protocol": "https",
    "host": "api.theboss.io",
    "token": "TOKEN",
})
volume = boss.get_cutout(
    boss.get_channel("CHAN", "COLL", "EXP"), 0,
    [0, 1024], [0, 1024], [1, 2], access_mode=CacheMode.raw,
)
```
The different possibilities of `access_mode` are listed below:
- access_mode = CacheMode.cache - _Utilizes the cache and checks for dirty keys_
- access_mode = CacheMode.no_cache - _Does not check the cache but does check for dirty keys_
- access_mode = CacheMode.raw - _Does not check the cache and DOES NOT check for dirty keys_

Please check jhuapl-boss/spdb#9 for testing method. 

NOTE: Unit Tests to check for these changes are still TO BE DONE.