### PR TITLE
Convenience capabilities

### DIFF
--- a/intern/remote/boss/remote.py
+++ b/intern/remote/boss/remote.py
@@ -77,7 +77,7 @@ class BossRemote(Remote):
 
         Returns a representation of the BossRemote that lists the host.
         """
-        return f"<intern.remote.BossRemote [{self._config['Default']['host']}]>"
+        return "<intern.remote.BossRemote [" + self._config['Default']['host'] + "]>"
 
     def _init_project_service(self, version):
         """

--- a/intern/remote/boss/remote.py
+++ b/intern/remote/boss/remote.py
@@ -71,6 +71,14 @@ class BossRemote(Remote):
         self._init_metadata_service(version)
         self._init_volume_service(version)
 
+    def __repr__(self):
+        """
+        Stringify the Remote.
+
+        Returns a representation of the BossRemote that lists the host.
+        """
+        return f"<intern.remote.BossRemote [{self._config['Default']['host']}]>"
+
     def _init_project_service(self, version):
         """
         Method to initialize the Project Service from the config data

--- a/intern/remote/boss/remote.py
+++ b/intern/remote/boss/remote.py
@@ -883,7 +883,9 @@ class BossRemote(Remote):
             requester.
 
             Args:
-                resource (intern.resource.boss.resource.ChannelResource): Channel or layer resource.
+                resource (intern.resource.boss.resource.ChannelResource | str): Channel or layer Resource. If a 
+                    string is provided instead, BossRemote.parse_bossURI is called instead on a URI-formatted 
+                    string of the form `bossdb://collection/experiment/channel`.
                 resolution (int): 0 indicates native resolution.
                 x_range (list[int]): x range such as [10, 20] which means x>=10 and x<20.
                 y_range (list[int]): y range such as [10, 20] which means y>=10 and y<20.

--- a/intern/remote/boss/remote.py
+++ b/intern/remote/boss/remote.py
@@ -1,4 +1,4 @@
-﻿"""
+"""
 # Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -872,7 +872,7 @@ class BossRemote(Remote):
         t = uri.split("://")[1].split("/")
         if len(t) is 3:
             return self.get_channel(t[2], t[0], t[1])
-        raise ValueError(f"Cannot parse URI {uri}.")
+        raise ValueError("Cannot parse URI " + uri + ".")
 
     def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[], no_cache=True, **kwargs):
             """Get a cutout from the volume service.

--- a/intern/remote/boss/remote.py
+++ b/intern/remote/boss/remote.py
@@ -858,7 +858,7 @@ class BossRemote(Remote):
         self.metadata_service.set_auth(self._token_metadata)
         self.metadata_service.delete(resource, keys)
 
-    def parse_bossURI(self, uri: str) -> Resource:
+    def parse_bossURI(self, uri): # type: (str) -> Resource
         """
         Parse a bossDB URI and handle malform errors.
 

--- a/intern/remote/boss/remote.py
+++ b/intern/remote/boss/remote.py
@@ -863,7 +863,7 @@ class BossRemote(Remote):
         Parse a bossDB URI and handle malform errors.
 
         Arguments:
-            uri (str): URI of the form bossdb://<collection/<experiment>/<channel>
+            uri (str): URI of the form bossdb://<collection>/<experiment>/<channel>
 
         Returns:
             Resource

--- a/intern/remote/boss/remote.py
+++ b/intern/remote/boss/remote.py
@@ -858,6 +858,22 @@ class BossRemote(Remote):
         self.metadata_service.set_auth(self._token_metadata)
         self.metadata_service.delete(resource, keys)
 
+    def parse_bossURI(self, uri: str) -> Resource:
+        """
+        Parse a bossDB URI and handle malform errors.
+
+        Arguments:
+            uri (str): URI of the form bossdb://<collection/<experiment>/<channel>
+
+        Returns:
+            Resource
+
+        """
+        t = uri.split("://")[1].split("/")
+        if len(t) is 3:
+            return self.get_channel(t[2], t[0], t[1])
+        raise ValueError(f"Cannot parse URI {uri}.")
+
     def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[], no_cache=True, **kwargs):
             """Get a cutout from the volume service.
 
@@ -874,7 +890,7 @@ class BossRemote(Remote):
                 z_range (list[int]): z range such as [10, 20] which means z>=10 and z<20.
                 time_range (optional [list[int]]): time range such as [30, 40] which means t>=30 and t<40.
                 id_list (optional [list[int]]): list of object ids to filter the cutout by.
-                no_cache (optional [boolean]): specifies the use of cache to be True or False. 
+                no_cache (optional [boolean]): specifies the use of cache to be True or False.
 
             Returns:
                 (numpy.array): A 3D or 4D (time) numpy matrix in (time)ZYX order.
@@ -882,5 +898,6 @@ class BossRemote(Remote):
             Raises:
                 requests.HTTPError on error.
             """
-
+            if isinstance(resource, str):
+                resource = self.parse_bossURI(resource)
             return self._volume.get_cutout(resource, resolution, x_range, y_range, z_range, time_range, id_list, no_cache, **kwargs)


### PR DESCRIPTION
- [x] Support passing bossURI to get_cutout to alias verbose calls to `get_channel`
- [x] More helpful `__repr__` string representation of boss remotes (so that `str(BossRemote)` gives helpful information such as hostname)