### PR TITLE
Adds get_cutout_link function

### DIFF
--- a/intern/remote/boss/remote.py
+++ b/intern/remote/boss/remote.py
@@ -877,7 +877,7 @@ class BossRemote(Remote):
 
             return self._volume.get_cutout(resource, resolution, x_range, y_range, z_range, time_range, id_list, no_cache, **kwargs)
 
-    def get_cutout_link(self, resource, resolution, x_range, y_range, z_range, time_range=None, **kwargs):
+    def get_neuroglancer_link(self, resource, resolution, x_range, y_range, z_range, time_range=None, **kwargs):
             """
             Get a neuroglancer link of the cutout specified from the host specified in the remote configuration step. 
 
@@ -896,4 +896,4 @@ class BossRemote(Remote):
                 RuntimeError when given invalid resource.
                 Other exceptions may be raised depending on the volume service's implementation.
             """
-            return self._volume.get_cutout_link(resource, resolution, x_range, y_range, z_range, time_range, **kwargs)
+            return self._volume.get_neuroglancer_link(resource, resolution, x_range, y_range, z_range, time_range, **kwargs)

--- a/intern/remote/boss/remote.py
+++ b/intern/remote/boss/remote.py
@@ -876,3 +876,24 @@ class BossRemote(Remote):
             """
 
             return self._volume.get_cutout(resource, resolution, x_range, y_range, z_range, time_range, id_list, no_cache, **kwargs)
+
+    def get_cutout_link(self, resource, resolution, x_range, y_range, z_range, time_range=None, **kwargs):
+            """
+            Get a neuroglancer link of the cutout specified from the host specified in the remote configuration step. 
+
+            Args:
+                resource (intern.resource.Resource): Resource compatible with cutout operations.
+                resolution (int): 0 indicates native resolution.
+                x_range (list[int]): x range such as [10, 20] which means x>=10 and x<20.
+                y_range (list[int]): y range such as [10, 20] which means y>=10 and y<20.
+                z_range (list[int]): z range such as [10, 20] which means z>=10 and z<20.
+                time_range (optional [list[int]]): time range such as [30, 40] which means t>=30 and t<40.
+
+            Returns:
+                (string): Return neuroglancer link.
+
+            Raises:
+                RuntimeError when given invalid resource.
+                Other exceptions may be raised depending on the volume service's implementation.
+            """
+            return self._volume.get_cutout_link(resource, resolution, x_range, y_range, z_range, time_range, **kwargs)

--- a/intern/remote/boss/remote.py
+++ b/intern/remote/boss/remote.py
@@ -877,7 +877,7 @@ class BossRemote(Remote):
 
             return self._volume.get_cutout(resource, resolution, x_range, y_range, z_range, time_range, id_list, no_cache, **kwargs)
 
-    def get_neuroglancer_link(self, resource, resolution, x_range, y_range, z_range, time_range=None, **kwargs):
+    def get_neuroglancer_link(self, resource, resolution, x_range, y_range, z_range, **kwargs):
             """
             Get a neuroglancer link of the cutout specified from the host specified in the remote configuration step. 
 
@@ -887,7 +887,6 @@ class BossRemote(Remote):
                 x_range (list[int]): x range such as [10, 20] which means x>=10 and x<20.
                 y_range (list[int]): y range such as [10, 20] which means y>=10 and y<20.
                 z_range (list[int]): z range such as [10, 20] which means z>=10 and z<20.
-                time_range (optional [list[int]]): time range such as [30, 40] which means t>=30 and t<40.
 
             Returns:
                 (string): Return neuroglancer link.
@@ -896,4 +895,4 @@ class BossRemote(Remote):
                 RuntimeError when given invalid resource.
                 Other exceptions may be raised depending on the volume service's implementation.
             """
-            return self._volume.get_neuroglancer_link(resource, resolution, x_range, y_range, z_range, time_range, **kwargs)
+            return self._volume.get_neuroglancer_link(resource, resolution, x_range, y_range, z_range, **kwargs)

--- a/intern/service/boss/v1/volume.py
+++ b/intern/service/boss/v1/volume.py
@@ -318,3 +318,26 @@ class VolumeService_1(BaseVersion):
         msg = ('Get bounding box failed on {}, got HTTP response: ({}) - {}'.format(
             resource.name, resp.status_code, resp.text))
         raise HTTPError(msg, request=req, response=resp)
+
+    def get_cutout_link(self, resource, resolution, x_range, y_range, z_range, time_range, url_prefix, **kwargs):
+        """
+        Get a neuroglancer link of the cutout specified from the host specified in the remote configuration step. 
+
+        Args:
+            resource (intern.resource.Resource): Resource compatible with cutout operations.
+            resolution (int): 0 indicates native resolution.
+            x_range (list[int]): x range such as [10, 20] which means x>=10 and x<20.
+            y_range (list[int]): y range such as [10, 20] which means y>=10 and y<20.
+            z_range (list[int]): z range such as [10, 20] which means z>=10 and z<20.
+            time_range (optional [list[int]]): time range such as [30, 40] which means t>=30 and t<40.
+            url_prefix (string): Protocol + host such as https://api.theboss.io
+
+        Returns:
+            (string): Return neuroglancer link.
+
+        Raises:
+            RuntimeError when given invalid resource.
+            Other exceptions may be raised depending on the volume service's implementation.
+        """
+        link = "https://neuroglancer.theboss.io/#!{'layers':{'" + str(resource.name)   + "':{'type':'" + resource.type + "'_'source':" + "'boss://" + url_prefix+ "/" + resource.coll_name + "/" + resource.exp_name + "/" + resource.name + "'}}_'navigation':{'pose':{'position':{'voxelCoordinates':[" + str(x_range[0]) + "_" + str(y_range[0]) + "_" + str(z_range[0]) + "]}}}}"
+        return link

--- a/intern/service/boss/v1/volume.py
+++ b/intern/service/boss/v1/volume.py
@@ -319,7 +319,7 @@ class VolumeService_1(BaseVersion):
             resource.name, resp.status_code, resp.text))
         raise HTTPError(msg, request=req, response=resp)
 
-    def get_neuroglancer_link(self, resource, resolution, x_range, y_range, z_range, time_range, url_prefix, **kwargs):
+    def get_neuroglancer_link(self, resource, resolution, x_range, y_range, z_range, url_prefix, **kwargs):
         """
         Get a neuroglancer link of the cutout specified from the host specified in the remote configuration step. 
 
@@ -329,7 +329,6 @@ class VolumeService_1(BaseVersion):
             x_range (list[int]): x range such as [10, 20] which means x>=10 and x<20.
             y_range (list[int]): y range such as [10, 20] which means y>=10 and y<20.
             z_range (list[int]): z range such as [10, 20] which means z>=10 and z<20.
-            time_range (optional [list[int]]): time range such as [30, 40] which means t>=30 and t<40.
             url_prefix (string): Protocol + host such as https://api.theboss.io
 
         Returns:

--- a/intern/service/boss/v1/volume.py
+++ b/intern/service/boss/v1/volume.py
@@ -319,7 +319,7 @@ class VolumeService_1(BaseVersion):
             resource.name, resp.status_code, resp.text))
         raise HTTPError(msg, request=req, response=resp)
 
-    def get_cutout_link(self, resource, resolution, x_range, y_range, z_range, time_range, url_prefix, **kwargs):
+    def get_neuroglancer_link(self, resource, resolution, x_range, y_range, z_range, time_range, url_prefix, **kwargs):
         """
         Get a neuroglancer link of the cutout specified from the host specified in the remote configuration step. 
 

--- a/intern/service/boss/volume.py
+++ b/intern/service/boss/volume.py
@@ -166,7 +166,7 @@ class VolumeService(BossService):
             self.url_prefix, self.auth, self.session, self.session_send_opts)
 
     @check_channel
-    def get_cutout_link(self, resource, resolution, x_range, y_range, z_range, time_range, **kwargs):
+    def get_neuroglancer_link(self, resource, resolution, x_range, y_range, z_range, time_range, **kwargs):
         """
         Get a neuroglancer link of the cutout specified from the host specified in the remote configuration step. 
 
@@ -185,4 +185,4 @@ class VolumeService(BossService):
             RuntimeError when given invalid resource.
             Other exceptions may be raised depending on the volume service's implementation.
         """
-        return self.service.get_cutout_link(resource, resolution, x_range, y_range, z_range, time_range, self.url_prefix, **kwargs)
+        return self.service.get_neuroglancer_link(resource, resolution, x_range, y_range, z_range, time_range, self.url_prefix, **kwargs)

--- a/intern/service/boss/volume.py
+++ b/intern/service/boss/volume.py
@@ -166,7 +166,7 @@ class VolumeService(BossService):
             self.url_prefix, self.auth, self.session, self.session_send_opts)
 
     @check_channel
-    def get_neuroglancer_link(self, resource, resolution, x_range, y_range, z_range, time_range, **kwargs):
+    def get_neuroglancer_link(self, resource, resolution, x_range, y_range, z_range, **kwargs):
         """
         Get a neuroglancer link of the cutout specified from the host specified in the remote configuration step. 
 
@@ -176,7 +176,6 @@ class VolumeService(BossService):
             x_range (list[int]): x range such as [10, 20] which means x>=10 and x<20.
             y_range (list[int]): y range such as [10, 20] which means y>=10 and y<20.
             z_range (list[int]): z range such as [10, 20] which means z>=10 and z<20.
-            time_range (optional [list[int]]): time range such as [30, 40] which means t>=30 and t<40.
 
         Returns:
             (string): Return neuroglancer link.
@@ -185,4 +184,4 @@ class VolumeService(BossService):
             RuntimeError when given invalid resource.
             Other exceptions may be raised depending on the volume service's implementation.
         """
-        return self.service.get_neuroglancer_link(resource, resolution, x_range, y_range, z_range, time_range, self.url_prefix, **kwargs)
+        return self.service.get_neuroglancer_link(resource, resolution, x_range, y_range, z_range, self.url_prefix, **kwargs)

--- a/intern/service/boss/volume.py
+++ b/intern/service/boss/volume.py
@@ -165,3 +165,24 @@ class VolumeService(BossService):
             resource, resolution, x_range, y_range, z_range, time_range,
             self.url_prefix, self.auth, self.session, self.session_send_opts)
 
+    @check_channel
+    def get_cutout_link(self, resource, resolution, x_range, y_range, z_range, time_range, **kwargs):
+        """
+        Get a neuroglancer link of the cutout specified from the host specified in the remote configuration step. 
+
+        Args:
+            resource (intern.resource.Resource): Resource compatible with cutout operations.
+            resolution (int): 0 indicates native resolution.
+            x_range (list[int]): x range such as [10, 20] which means x>=10 and x<20.
+            y_range (list[int]): y range such as [10, 20] which means y>=10 and y<20.
+            z_range (list[int]): z range such as [10, 20] which means z>=10 and z<20.
+            time_range (optional [list[int]]): time range such as [30, 40] which means t>=30 and t<40.
+
+        Returns:
+            (string): Return neuroglancer link.
+
+        Raises:
+            RuntimeError when given invalid resource.
+            Other exceptions may be raised depending on the volume service's implementation.
+        """
+        return self.service.get_cutout_link(resource, resolution, x_range, y_range, z_range, time_range, self.url_prefix, **kwargs)


### PR DESCRIPTION
Simple function to get the neuroglancer url link of a channel given the same parameters as the `get_cutout` function. 

Only available for the boss remote. 

Let me know if perhaps the code should be moved to another location. Thought volume service would be the most appropriate. 

Sample script:
```python
import intern
from intern.remote.boss import BossRemote

rmt = BossRemote({
    "protocol": "https",
    "host": "api.theboss.io",
    "token": "TOKEN"
})

# params
col = 'kasthuri2015'
exp = 'em'
chan = 'cc'
initial_res = 0

#Bounds
x_bounds = [6400,6400+100]
y_bounds = [9000,9000+100]
z_bounds = [843, 848]

#Get link
neuroLink= rmt.get_neuroglancer_link(rmt.get_channel(chan, col, exp),initial_res,x_bounds,y_bounds,z_bounds,)
print(neuroLink)
```
>Output: https://neuroglancer.theboss.io/#!{'layers':{'cc':{'type':'image'_'source':'boss://https://api.theboss.io/kasthuri2015/em/cc'}}_'navigation':{'pose':{'position':{'voxelCoordinates':[6400_9000_843]}}}}