### PR TITLE
Add chunking procedure to create_cutout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 ____________
+## v0.9.11
+* `create_cutout` will now chunk large cutouts into smaller components to eliminate HTTP size limitation and timeout errors.
+
 ## v0.9.10
 *  Intern now forwards no_cache option when breaking apart large cutouts.
 

--- a/intern/service/boss/v1/tests/test_volume.py
+++ b/intern/service/boss/v1/tests/test_volume.py
@@ -50,6 +50,27 @@ class TestVolume_v1(unittest.TestCase):
             url_prefix, auth, mock_session, send_opts)
 
     @patch('requests.Session', autospec=True)
+    def test_create_large_cutout_success(self, mock_session):
+        resolution = 0
+        x_range = [3000, 6000]
+        y_range = [3000, 6000]
+        z_range = [30, 62]
+        time_range = [10, 25]
+        data = numpy.random.randint(0, 3000, (15, 20, 20, 20), numpy.uint16)
+        url_prefix = 'https://api.theboss.io'
+        auth = 'mytoken'
+
+        mock_session.prepare_request.return_value = PreparedRequest()
+        fake_response = Response()
+        fake_response.status_code = 201
+        mock_session.send.return_value = fake_response
+        send_opts = {}
+
+        self.vol.create_cutout(
+            self.chan, resolution, x_range, y_range, z_range, time_range, data,
+            url_prefix, auth, mock_session, send_opts)
+
+    @patch('requests.Session', autospec=True)
     def test_create_cutout_failure(self, mock_session):
         resolution = 0
         x_range = [20, 40]

--- a/intern/service/boss/v1/tests/test_volume.py
+++ b/intern/service/boss/v1/tests/test_volume.py
@@ -54,7 +54,7 @@ class TestVolume_v1(unittest.TestCase):
         resolution = 0
         x_range = [3000, 6000]
         y_range = [3000, 6000]
-        z_range = [30, 62]
+        z_range = [30, 63]
         time_range = [10, 25]
         data = numpy.random.randint(0, 3000, (15, 20, 20, 20), numpy.uint16)
         url_prefix = 'https://api.theboss.io'

--- a/intern/service/boss/v1/volume.py
+++ b/intern/service/boss/v1/volume.py
@@ -59,7 +59,6 @@ class VolumeService_1(BaseVersion):
             session (requests.Session): HTTP session to use for request.
             send_opts (dictionary): Additional arguments to pass to session.send().
         """
-        compressed = blosc.compress(numpyVolume, typesize=self.get_bit_width(resource))
 
         if numpyVolume.ndim == 3:
             # Can't have time
@@ -77,6 +76,35 @@ class VolumeService_1(BaseVersion):
                 "Number of dimensions: {}".format(numpyVolume.ndim)
             )
 
+        # Check to see if this volume is larger than 1GB. If so, chunk it into
+        # several smaller bites:
+        if (
+                (x_range[1] - x_range[0]) *
+                (y_range[1] - y_range[0]) *
+                (z_range[1] - z_range[0])
+        ) > 1024 * 1024 * 32 * 2:
+            blocks = block_compute(
+                x_range[0], x_range[1],
+                y_range[0], y_range[1],
+                z_range[0], z_range[1],
+                block_size=(1024, 1024, 32)
+            )
+
+            for b in blocks:
+                _data = numpyVolume[
+                    b[2][0] - z_range[0]: b[2][1] - z_range[0],
+                    b[1][0] - y_range[0]: b[1][1] - y_range[0],
+                    b[0][0] - x_range[0]: b[0][1] - x_range[0]
+                ]
+                self.create_cutout(
+                    resource, resolution, b[0], b[1], b[2],
+                    time_range, _data, url_prefix, auth, session, send_opts
+                )
+            return
+
+        compressed = blosc.compress(
+            numpyVolume, typesize=self.get_bit_width(resource)
+        )
         req = self.get_cutout_request(
             resource, 'POST', 'application/blosc',
             url_prefix, auth,
@@ -111,7 +139,7 @@ class VolumeService_1(BaseVersion):
             auth (string): Token to send in the request header.
             session (requests.Session): HTTP session to use for request.
             send_opts (dictionary): Additional arguments to pass to session.send().
-            no_cache (optional [boolean]): specifies the use of cache to be True or False. 
+            no_cache (optional [boolean]): specifies the use of cache to be True or False.
 
         Returns:
             (numpy.array): A 3D or 4D numpy matrix in ZXY(time) order.
@@ -143,7 +171,7 @@ class VolumeService_1(BaseVersion):
             for b in blocks:
                 _data = self.get_cutout(
                     resource, resolution, b[0], b[1], b[2],
-                    time_range, id_list, url_prefix, auth, session, send_opts, 
+                    time_range, id_list, url_prefix, auth, session, send_opts,
                     no_cache, **kwargs
                 )
 

--- a/intern/service/boss/v1/volume.py
+++ b/intern/service/boss/v1/volume.py
@@ -91,11 +91,14 @@ class VolumeService_1(BaseVersion):
             )
 
             for b in blocks:
-                _data = numpyVolume[
-                    b[2][0] - z_range[0]: b[2][1] - z_range[0],
-                    b[1][0] - y_range[0]: b[1][1] - y_range[0],
-                    b[0][0] - x_range[0]: b[0][1] - x_range[0]
-                ]
+                _data = np.ascontiguousarray(
+                    numpyVolume[
+                        b[2][0] - z_range[0]: b[2][1] - z_range[0],
+                        b[1][0] - y_range[0]: b[1][1] - y_range[0],
+                        b[0][0] - x_range[0]: b[0][1] - x_range[0]
+                    ],
+                    dtype=numpyVolume.dtype
+                )
                 self.create_cutout(
                     resource, resolution, b[0], b[1], b[2],
                     time_range, _data, url_prefix, auth, session, send_opts


### PR DESCRIPTION
On large chunks of data passed to create_cutout, chunk the data into smaller components to post individually (to avoid HTTP timeout or size limitation).