### PR TITLE
Create cutout res feature

### DIFF
--- a/intern/service/boss/v1/volume.py
+++ b/intern/service/boss/v1/volume.py
@@ -76,8 +76,8 @@ class VolumeService_1(BaseVersion):
                 "Number of dimensions: {}".format(numpyVolume.ndim)
             )
 
+        # If resolution is +1 base resolution then downsample the single tile and then create the cutout. 
         if resolution == resource.base_resolution + 1:
-
             if numpyVolume.dtype == np.uint8:
                 image_type = 'L'
             elif numpyVolume.dtype == np.uint16:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ blosc>=1.4.4
 six
 mock
 nose2
+Pillow


### PR DESCRIPTION
This is a quick intern feature that allows us to push a single tile of even dimensions to the boss in resolution = base_resolution +1. 

Script used for testing can be found here: https://github.com/aplmicrons/user-scratch/blob/master/rodrilm2/tests/testResolutionUp.py

As of right now only single tiles (z size 1) are allowed to be downsampled before creating the cutout. 

_This still needs to be allowed on the server side, just thought I'd make the PR, to get some reviews when possible_