### PR TITLE
Hotfixes to make master python2 compatible

### DIFF
--- a/intern/service/boss/baseversion.py
+++ b/intern/service/boss/baseversion.py
@@ -189,6 +189,12 @@ class BaseVersion(object):
         # If creating a cutout, the url will not include the access_mode otherwise it will
         if access_mode is not None:
             queryParamDict['access-mode'] = access_mode.value 
+        """
+        TODO: LMR
+        The following could be done using urlib.urlencode(urlWithParams += '?' + urllib.parse.urlencode(queryParamDict,safe=",")),
+        however urllib's python2 version of this function does not take in the 'safe' parameter and thus we can not use the 
+        function interchangable for python2/3. In order to keep our python2/3 compatability, we do not use urllib. 
+        """
         if queryParamDict:
             # The first time include '?'
             urlWithParams += '?'

--- a/intern/service/boss/baseversion.py
+++ b/intern/service/boss/baseversion.py
@@ -190,8 +190,17 @@ class BaseVersion(object):
         if access_mode is not None:
             queryParamDict['access-mode'] = access_mode.value 
         if queryParamDict:
+            # The first time include '?'
+            urlWithParams += '?'
             for k, v in queryParamDict.items():
-                urlWithParams += '?{}={}/'.format(k,v)
+                # if this is the first run through, last char in str will be ?, so don't include '&'
+                if urlWithParams[len(urlWithParams)-1] == '?':
+                    pass
+                # otherwise use '&'
+                else:
+                    urlWithParams += '&'
+                # Add key and value members
+                urlWithParams += '{}={}'.format(k,v)
         return urlWithParams
 
     def get_request(self, resource, method, content, url_prefix, token, proj_list_req=False, json=None, data=None):

--- a/intern/service/boss/baseversion.py
+++ b/intern/service/boss/baseversion.py
@@ -15,7 +15,6 @@ import six
 from abc import ABCMeta, abstractmethod
 from intern.resource.boss.resource import CoordinateFrameResource
 from requests import Request
-from six.moves import urllib
 
 @six.add_metaclass(ABCMeta)
 class BaseVersion(object):
@@ -191,7 +190,8 @@ class BaseVersion(object):
         if access_mode is not None:
             queryParamDict['access-mode'] = access_mode.value 
         if queryParamDict:
-            urlWithParams += '?' + urllib.parse.urlencode(queryParamDict,safe=",")
+            for k, v in queryParamDict:
+                urlWithParams += '?{}={}'.format(k,v)
         return urlWithParams
 
     def get_request(self, resource, method, content, url_prefix, token, proj_list_req=False, json=None, data=None):

--- a/intern/service/boss/baseversion.py
+++ b/intern/service/boss/baseversion.py
@@ -191,7 +191,7 @@ class BaseVersion(object):
             queryParamDict['access-mode'] = access_mode.value 
         if queryParamDict:
             for k, v in queryParamDict.items():
-                urlWithParams += '?{}={}'.format(k,v)
+                urlWithParams += '?{}={}/'.format(k,v)
         return urlWithParams
 
     def get_request(self, resource, method, content, url_prefix, token, proj_list_req=False, json=None, data=None):

--- a/intern/service/boss/baseversion.py
+++ b/intern/service/boss/baseversion.py
@@ -15,7 +15,7 @@ import six
 from abc import ABCMeta, abstractmethod
 from intern.resource.boss.resource import CoordinateFrameResource
 from requests import Request
-import urllib
+from six.moves import urllib
 
 @six.add_metaclass(ABCMeta)
 class BaseVersion(object):

--- a/intern/service/boss/baseversion.py
+++ b/intern/service/boss/baseversion.py
@@ -190,7 +190,7 @@ class BaseVersion(object):
         if access_mode is not None:
             queryParamDict['access-mode'] = access_mode.value 
         if queryParamDict:
-            for k, v in queryParamDict:
+            for k, v in queryParamDict.items():
                 urlWithParams += '?{}={}'.format(k,v)
         return urlWithParams
 


### PR DESCRIPTION
Had to make a hotfix to the access_mode update. 
Turns out urllib is very different between python2 and python3. Online most people recommend, if you want to have something that works well for both python2 and python3 you should just create the functions yourself.

Here I eliminate our dependency on urllib and create the url myself. 

Let me know if you have any suggestions. 