### PR TITLE
added long_description_content_type to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     version=__version__,
     description='Python SDK for interacting neuroscience data via the Boss API.',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     url='https://github.com/jhuapl-boss/intern',
     download_url='https://github.com/jhuapl-boss/intern/tarball/' + __version__,
     license='Apache 2.0',


### PR DESCRIPTION
twine now blocks uploads without long_description_content_type
Originally received this error:
_HTTPError: 400 Client Error: The description failed to render in the default format of reStructuredText_

https://github.com/pypa/warehouse/issues/5890