### PR TITLE
Inherit env variables from the shell session

### DIFF
--- a/intern/service/boss/service.py
+++ b/intern/service/boss/service.py
@@ -29,7 +29,7 @@ class BossService(Service):
         Service.__init__(self)
         self._versions = {}
         self._session = Session()
-        self._session_send_opts = {}
+        self._session_send_opts = self._session.merge_environment_settings(None, {}, None, None, None)
 
     def __del__(self):
         if self._session is not None:


### PR DESCRIPTION
`intern`'s `requests` calls should respect environment variables set in the shell.