### PR TITLE
BossRemote#get_cutout parallelism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Features
 
 -   Add support for DVID and cloud-volume hosted data with `DVIDRemote` and `CloudVolumeRemote`. (#46)
+-   Add parallelism to `BossRemote#get_cutout` calls by passing `parallel=True` or `parallel=<int # of jobs>` as an argument.
 
 ## v0.10.0 — April 16, 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Features
 
 -   Add support for DVID and cloud-volume hosted data with `DVIDRemote` and `CloudVolumeRemote`. (#46)
--   Add parallelism to `BossRemote#get_cutout` calls by passing `parallel=True` or `parallel=<int # of jobs>` as an argument.
+-   Add parallelism to `BossRemote#get_cutout` calls by passing `parallel=True` or `parallel=<int # of jobs>` as an argument. (#52)
 
 ## v0.10.0 — April 16, 2020
 

--- a/intern/remote/boss/remote.py
+++ b/intern/remote/boss/remote.py
@@ -875,7 +875,7 @@ class BossRemote(Remote):
             return self.get_channel(t[2], t[0], t[1])
         raise ValueError("Cannot parse URI " + uri + ".")
 
-    def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[], no_cache=None, access_mode=CacheMode.no_cache, **kwargs):
+    def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[], no_cache=None, access_mode=CacheMode.no_cache, parallel: bool = True, **kwargs):
             """Get a cutout from the volume service.
 
             Note that access_mode=no_cache is desirable when reading large amounts of
@@ -884,8 +884,8 @@ class BossRemote(Remote):
             requester.
 
             Args:
-                resource (intern.resource.boss.resource.ChannelResource | str): Channel or layer Resource. If a 
-                    string is provided instead, BossRemote.parse_bossURI is called instead on a URI-formatted 
+                resource (intern.resource.boss.resource.ChannelResource | str): Channel or layer Resource. If a
+                    string is provided instead, BossRemote.parse_bossURI is called instead on a URI-formatted
                     string of the form `bossdb://collection/experiment/channel`.
                 resolution (int): 0 indicates native resolution.
                 x_range (list[int]): x range such as [10, 20] which means x>=10 and x<20.
@@ -899,6 +899,7 @@ class BossRemote(Remote):
                     cache = Will check both cache and for dirty keys
                     no_cache = Will skip cache check but check for dirty keys
                     raw = Will skip both the cache and dirty keys check
+                parallel (bool: True): Whether downloads should be parallelized using multiprocessing
 
                 TODO: Add mode to documentation
 
@@ -915,17 +916,22 @@ class BossRemote(Remote):
             if no_cache and access_mode != CacheMode.no_cache:
                 warnings.warn("Both no_cache and access_mode were used, please use access_mode only. As no_cache has been deprecated. ")
                 warnings.warn("Your request will be made using the default mode no_cache.")
-                access_mode=CacheMode.no_cache    
+                access_mode=CacheMode.no_cache
             if no_cache:
                 access_mode=CacheMode.no_cache
             elif no_cache == False:
                 access_mode=CacheMode.cache
-            return self._volume.get_cutout(resource, resolution, x_range, y_range, z_range, time_range, id_list, access_mode, **kwargs)
+            return self._volume.get_cutout(
+                resource, resolution,
+                x_range, y_range, z_range, time_range,
+                id_list, access_mode,
+                parallel=parallel, **kwargs
+            )
 
     def get_experiment(self, coll_name, exp_name):
         """
         Convenience method that gets experiment resource.
-        
+
         Args:
             coll_name (str): Collection name
             exp_name (str): Experiment name
@@ -942,7 +948,7 @@ class BossRemote(Remote):
 
         Args:
             name (str): Name of the coordinate frame
-        
+
         Returns:
             (CoordinateFrameResource)
         """
@@ -951,7 +957,7 @@ class BossRemote(Remote):
 
     def get_neuroglancer_link(self, resource, resolution, x_range, y_range, z_range, **kwargs):
             """
-            Get a neuroglancer link of the cutout specified from the host specified in the remote configuration step. 
+            Get a neuroglancer link of the cutout specified from the host specified in the remote configuration step.
 
             Args:
                 resource (intern.resource.Resource): Resource compatible with cutout operations.
@@ -968,7 +974,7 @@ class BossRemote(Remote):
                 Other exceptions may be raised depending on the volume service's implementation.
             """
             return self._volume.get_neuroglancer_link(resource, resolution, x_range, y_range, z_range, **kwargs)
-    
+
     def get_extents(self, resource):
             """Get extents of the reource
 

--- a/intern/remote/boss/tests/test_remote_get_cutout.py
+++ b/intern/remote/boss/tests/test_remote_get_cutout.py
@@ -73,7 +73,7 @@ class TestRemoteGetCutout(unittest.TestCase):
         self.remote.get_cutout(chan, resolution, x_range, y_range, z_range, access_mode=CacheMode.cache)
         fake_volume.assert_called_with(
             ANY, chan, resolution, x_range, y_range, z_range, ANY, ANY,
-            CacheMode.cache, ANY)   # This should be the no_cache argument.
+            CacheMode.cache, parallel=ANY)   # This should be the no_cache argument.
 
 
     ##REMOVE IN THE FUTURE, TESTS BACKWARDS COMPATABILITY

--- a/intern/remote/boss/tests/test_remote_get_cutout.py
+++ b/intern/remote/boss/tests/test_remote_get_cutout.py
@@ -41,7 +41,7 @@ class TestRemoteGetCutout(unittest.TestCase):
         self.remote.get_cutout(chan, resolution, x_range, y_range, z_range)
         fake_volume.assert_called_with(
             ANY, chan, resolution, x_range, y_range, z_range, ANY, ANY,
-            CacheMode.no_cache)   # This should be the no_cache argument.
+            CacheMode.no_cache, ANY)   # This should be the no_cache argument.
 
     @patch.object(VolumeService, 'get_cutout', autospec=True)
     def test_get_cutout_access_mode_raw(self, fake_volume):
@@ -57,7 +57,7 @@ class TestRemoteGetCutout(unittest.TestCase):
         self.remote.get_cutout(chan, resolution, x_range, y_range, z_range, access_mode=CacheMode.raw)
         fake_volume.assert_called_with(
             ANY, chan, resolution, x_range, y_range, z_range, ANY, ANY,
-            CacheMode.raw)   # This should be the no_cache argument.
+            CacheMode.raw, ANY)   # This should be the no_cache argument.
 
     @patch.object(VolumeService, 'get_cutout', autospec=True)
     def test_get_cutout_access_mode_cache(self, fake_volume):
@@ -73,7 +73,7 @@ class TestRemoteGetCutout(unittest.TestCase):
         self.remote.get_cutout(chan, resolution, x_range, y_range, z_range, access_mode=CacheMode.cache)
         fake_volume.assert_called_with(
             ANY, chan, resolution, x_range, y_range, z_range, ANY, ANY,
-            CacheMode.cache, parallel=ANY)   # This should be the no_cache argument.
+            CacheMode.cache, ANY)   # This should be the no_cache argument.
 
 
     ##REMOVE IN THE FUTURE, TESTS BACKWARDS COMPATABILITY
@@ -91,7 +91,7 @@ class TestRemoteGetCutout(unittest.TestCase):
         self.remote.get_cutout(chan, resolution, x_range, y_range, z_range, no_cache=True)
         fake_volume.assert_called_with(
             ANY, chan, resolution, x_range, y_range, z_range, ANY, ANY,
-            CacheMode.no_cache)   # This should be the no_cache argument.
+            CacheMode.no_cache, ANY)   # This should be the no_cache argument.
 
     @patch.object(VolumeService, 'get_cutout', autospec=True)
     def test_get_cutout_no_cache_False_backwards_compatability(self, fake_volume):
@@ -107,6 +107,6 @@ class TestRemoteGetCutout(unittest.TestCase):
         self.remote.get_cutout(chan, resolution, x_range, y_range, z_range, no_cache=False)
         fake_volume.assert_called_with(
             ANY, chan, resolution, x_range, y_range, z_range, ANY, ANY,
-            CacheMode.cache)   # This should be the no_cache argument.
+            CacheMode.cache, ANY)   # This should be the no_cache argument.
 if __name__ == '__main__':
     unittest.main()

--- a/intern/remote/boss/tests/test_remote_get_cutout.py
+++ b/intern/remote/boss/tests/test_remote_get_cutout.py
@@ -73,9 +73,9 @@ class TestRemoteGetCutout(unittest.TestCase):
         self.remote.get_cutout(chan, resolution, x_range, y_range, z_range, access_mode=CacheMode.cache)
         fake_volume.assert_called_with(
             ANY, chan, resolution, x_range, y_range, z_range, ANY, ANY,
-            CacheMode.cache)   # This should be the no_cache argument.
+            CacheMode.cache, ANY)   # This should be the no_cache argument.
 
-    
+
     ##REMOVE IN THE FUTURE, TESTS BACKWARDS COMPATABILITY
     @patch.object(VolumeService, 'get_cutout', autospec=True)
     def test_get_cutout_no_cache_True_backwards_compatability(self, fake_volume):

--- a/intern/remote/boss/tests/test_remote_get_cutout.py
+++ b/intern/remote/boss/tests/test_remote_get_cutout.py
@@ -41,7 +41,7 @@ class TestRemoteGetCutout(unittest.TestCase):
         self.remote.get_cutout(chan, resolution, x_range, y_range, z_range)
         fake_volume.assert_called_with(
             ANY, chan, resolution, x_range, y_range, z_range, ANY, ANY,
-            CacheMode.no_cache, ANY)   # This should be the no_cache argument.
+            CacheMode.no_cache, parallel=True)   # This should be the no_cache argument.
 
     @patch.object(VolumeService, 'get_cutout', autospec=True)
     def test_get_cutout_access_mode_raw(self, fake_volume):
@@ -57,7 +57,7 @@ class TestRemoteGetCutout(unittest.TestCase):
         self.remote.get_cutout(chan, resolution, x_range, y_range, z_range, access_mode=CacheMode.raw)
         fake_volume.assert_called_with(
             ANY, chan, resolution, x_range, y_range, z_range, ANY, ANY,
-            CacheMode.raw, ANY)   # This should be the no_cache argument.
+            CacheMode.raw, parallel=True)   # This should be the no_cache argument.
 
     @patch.object(VolumeService, 'get_cutout', autospec=True)
     def test_get_cutout_access_mode_cache(self, fake_volume):
@@ -73,7 +73,7 @@ class TestRemoteGetCutout(unittest.TestCase):
         self.remote.get_cutout(chan, resolution, x_range, y_range, z_range, access_mode=CacheMode.cache)
         fake_volume.assert_called_with(
             ANY, chan, resolution, x_range, y_range, z_range, ANY, ANY,
-            CacheMode.cache, ANY)   # This should be the no_cache argument.
+            CacheMode.cache, parallel=True)   # This should be the no_cache argument.
 
 
     ##REMOVE IN THE FUTURE, TESTS BACKWARDS COMPATABILITY
@@ -91,7 +91,7 @@ class TestRemoteGetCutout(unittest.TestCase):
         self.remote.get_cutout(chan, resolution, x_range, y_range, z_range, no_cache=True)
         fake_volume.assert_called_with(
             ANY, chan, resolution, x_range, y_range, z_range, ANY, ANY,
-            CacheMode.no_cache, ANY)   # This should be the no_cache argument.
+            CacheMode.no_cache, parallel=True)   # This should be the no_cache argument.
 
     @patch.object(VolumeService, 'get_cutout', autospec=True)
     def test_get_cutout_no_cache_False_backwards_compatability(self, fake_volume):
@@ -107,6 +107,6 @@ class TestRemoteGetCutout(unittest.TestCase):
         self.remote.get_cutout(chan, resolution, x_range, y_range, z_range, no_cache=False)
         fake_volume.assert_called_with(
             ANY, chan, resolution, x_range, y_range, z_range, ANY, ANY,
-            CacheMode.cache, ANY)   # This should be the no_cache argument.
+            CacheMode.cache, parallel=True)   # This should be the no_cache argument.
 if __name__ == '__main__':
     unittest.main()

--- a/intern/remote/remote.py
+++ b/intern/remote/remote.py
@@ -125,7 +125,7 @@ class Remote(object):
         """
         return self._project.list(**kwargs)
 
-    def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[], **kwargs):
+    def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[], parallel: bool= True, **kwargs):
         """Get a cutout from the volume service.
 
         Args:
@@ -136,6 +136,7 @@ class Remote(object):
             z_range (list[int]): z range such as [10, 20] which means z>=10 and z<20.
             time_range (optional [list[int]]): time range such as [30, 40] which means t>=30 and t<40.
             id_list (optional [list]): list of object ids to filter the cutout by.
+            parallel (bool: True): Whether downloads should be parallelized using multiprocessing
 
         Returns:
             (): Return type depends on volume service's implementation.
@@ -148,7 +149,10 @@ class Remote(object):
         if not resource.valid_volume():
             raise RuntimeError('Resource incompatible with the volume service.')
         return self._volume.get_cutout(
-            resource, resolution, x_range, y_range, z_range, time_range, id_list, **kwargs)
+            resource, resolution,
+            x_range, y_range, z_range, time_range,
+            id_list, parallel = parallel, **kwargs
+        )
 
     def create_cutout(self, resource, resolution, x_range, y_range, z_range, data, time_range=None):
         """Upload a cutout to the volume service.
@@ -197,7 +201,7 @@ class Remote(object):
 
         Returns:
             extents (array): [[x-min, max-x], [y-min, max-y], [z-min, max-z]]
-        """ 
+        """
         return self._metadata.get_extents(resource)
 
     def get_bounding_box(self, resource, resolution, id, bb_type='loose'):

--- a/intern/service/boss/v1/tests/test_volume.py
+++ b/intern/service/boss/v1/tests/test_volume.py
@@ -331,7 +331,7 @@ class TestVolume_v1(unittest.TestCase):
             self.vol.get_cutout(self.chan, resolution, x_range, y_range, z_range,
                 time_range, id_list, url_prefix, auth, mock_session, send_opts, access_mode=CacheMode.cache)
             req_spy.assert_called_with(ANY, ANY, 'GET', ANY, url_prefix, auth, resolution,
-                x_range, y_range, z_range, time_range, id_list=[], access_mode=CacheMode.cache, ANY)
+                x_range, y_range, z_range, time_range, id_list=[], access_mode=CacheMode.cache, parallel=ANY)
             self.assertEqual(1, req_spy.call_count)
 
     @patch('requests.Response', autospec=True)

--- a/intern/service/boss/v1/tests/test_volume.py
+++ b/intern/service/boss/v1/tests/test_volume.py
@@ -171,7 +171,7 @@ class TestVolume_v1(unittest.TestCase):
 
         with patch.object(
                 BaseVersion, 'get_cutout_request', autospec=True, wraps=BaseVersion.get_cutout_request) as req_spy:
-            self.vol.get_cutout(self.chan, resolution, x_range, y_range, z_range, 
+            self.vol.get_cutout(self.chan, resolution, x_range, y_range, z_range,
                 time_range, id_list, url_prefix, auth, mock_session, send_opts)
             req_spy.assert_called_with(ANY, ANY, 'GET', ANY, url_prefix, auth, resolution,
                 x_range, y_range, z_range, time_range, id_list=[], access_mode=CacheMode.no_cache)
@@ -203,7 +203,7 @@ class TestVolume_v1(unittest.TestCase):
 
         with patch.object(
                 BaseVersion, 'get_cutout_request', autospec=True, wraps=BaseVersion.get_cutout_request) as req_spy:
-            self.vol.get_cutout(self.chan, resolution, x_range, y_range, z_range, 
+            self.vol.get_cutout(self.chan, resolution, x_range, y_range, z_range,
                 time_range, id_list, url_prefix, auth, mock_session, send_opts)
             req_spy.assert_called_with(ANY, ANY, 'GET', ANY, url_prefix, auth, resolution,
                 ANY, ANY, ANY, ANY, id_list=[], access_mode=CacheMode.no_cache)
@@ -235,7 +235,7 @@ class TestVolume_v1(unittest.TestCase):
 
         with patch.object(
                 BaseVersion, 'get_cutout_request', autospec=True, wraps=BaseVersion.get_cutout_request) as req_spy:
-            self.vol.get_cutout(self.chan, resolution, x_range, y_range, z_range, 
+            self.vol.get_cutout(self.chan, resolution, x_range, y_range, z_range,
                 time_range, id_list, url_prefix, auth, mock_session, send_opts, access_mode=CacheMode.raw)
             req_spy.assert_called_with(ANY, ANY, 'GET', ANY, url_prefix, auth, resolution,
                 x_range, y_range, z_range, time_range, id_list=[], access_mode=CacheMode.raw)
@@ -266,7 +266,7 @@ class TestVolume_v1(unittest.TestCase):
 
         with patch.object(
                 BaseVersion, 'get_cutout_request', autospec=True, wraps=BaseVersion.get_cutout_request) as req_spy:
-            self.vol.get_cutout(self.chan, resolution, x_range, y_range, z_range, 
+            self.vol.get_cutout(self.chan, resolution, x_range, y_range, z_range,
                 time_range, id_list, url_prefix, auth, mock_session, send_opts, access_mode=CacheMode.raw)
             req_spy.assert_called_with(ANY, ANY, 'GET', ANY, url_prefix, auth, resolution,
                 x_range, y_range, z_range, time_range, id_list=[], access_mode=CacheMode.raw)
@@ -297,7 +297,7 @@ class TestVolume_v1(unittest.TestCase):
 
         with patch.object(
                 BaseVersion, 'get_cutout_request', autospec=True, wraps=BaseVersion.get_cutout_request) as req_spy:
-            self.vol.get_cutout(self.chan, resolution, x_range, y_range, z_range, 
+            self.vol.get_cutout(self.chan, resolution, x_range, y_range, z_range,
                 time_range, id_list, url_prefix, auth, mock_session, send_opts, access_mode=CacheMode.cache)
             req_spy.assert_called_with(ANY, ANY, 'GET', ANY, url_prefix, auth, resolution,
                 x_range, y_range, z_range, time_range, id_list=[], access_mode=CacheMode.cache)
@@ -328,10 +328,10 @@ class TestVolume_v1(unittest.TestCase):
 
         with patch.object(
                 BaseVersion, 'get_cutout_request', autospec=True, wraps=BaseVersion.get_cutout_request) as req_spy:
-            self.vol.get_cutout(self.chan, resolution, x_range, y_range, z_range, 
+            self.vol.get_cutout(self.chan, resolution, x_range, y_range, z_range,
                 time_range, id_list, url_prefix, auth, mock_session, send_opts, access_mode=CacheMode.cache)
             req_spy.assert_called_with(ANY, ANY, 'GET', ANY, url_prefix, auth, resolution,
-                x_range, y_range, z_range, time_range, id_list=[], access_mode=CacheMode.cache)
+                x_range, y_range, z_range, time_range, id_list=[], access_mode=CacheMode.cache, ANY)
             self.assertEqual(1, req_spy.call_count)
 
     @patch('requests.Response', autospec=True)

--- a/intern/service/boss/v1/tests/test_volume.py
+++ b/intern/service/boss/v1/tests/test_volume.py
@@ -331,7 +331,7 @@ class TestVolume_v1(unittest.TestCase):
             self.vol.get_cutout(self.chan, resolution, x_range, y_range, z_range,
                 time_range, id_list, url_prefix, auth, mock_session, send_opts, access_mode=CacheMode.cache)
             req_spy.assert_called_with(ANY, ANY, 'GET', ANY, url_prefix, auth, resolution,
-                x_range, y_range, z_range, time_range, id_list=[], access_mode=CacheMode.cache, parallel=ANY)
+                x_range, y_range, z_range, time_range, id_list=[], access_mode=CacheMode.cache)
             self.assertEqual(1, req_spy.call_count)
 
     @patch('requests.Response', autospec=True)


### PR DESCRIPTION
You can now pass a `parallel=True` (will use your number of cores) or `parallel=<int number of jobs>` argument to `BossRemote#get_cutout` in order to spread chunk downloads over a `multiprocessing.Pool#starmap`.

On a few informal stress-tests, this improved download speed by 37–40%.

You can still use the old behavior with `parallel=False`.