### PR TITLE
cutout_to_black addition to BossRemote

### DIFF
--- a/intern/remote/boss/remote.py
+++ b/intern/remote/boss/remote.py
@@ -927,7 +927,30 @@ class BossRemote(Remote):
                 id_list, access_mode,
                 parallel=parallel, **kwargs
             )
+    
+    def create_cutout_to_black(self, resource, resolution, x_range, y_range, z_range, time_range=None):
+        """Post a black cutout to the volume service.
 
+        Args:
+            resource (intern.resource.Resource): Resource compatible with cutout operations.
+            resolution (int): 0 indicates native resolution.
+            x_range (list[int]): x range such as [10, 20] which means x>=10 and x<20.
+            y_range (list[int]): y range such as [10, 20] which means y>=10 and y<20.
+            z_range (list[int]): z range such as [10, 20] which means z>=10 and z<20.
+            time_range (optional [list[int]]): time range such as [30, 40] which means t>=30 and t<40.
+
+        Returns:
+            (): Return type depends on volume service's implementation.
+
+        Raises:
+            RuntimeError when given invalid resource.
+            Other exceptions may be raised depending on the volume service's implementation.
+        """
+        if not resource.valid_volume():
+            raise RuntimeError('Resource incompatible with the volume service.')
+        return self._volume.create_cutout_to_black(
+            resource, resolution, x_range, y_range, z_range, time_range)
+        
     def get_experiment(self, coll_name, exp_name):
         """
         Convenience method that gets experiment resource.

--- a/intern/remote/boss/tests/int_test_volume_v1.py
+++ b/intern/remote/boss/tests/int_test_volume_v1.py
@@ -935,7 +935,7 @@ class VolumeServiceTest_v1(unittest.TestCase):
         data = data.astype(numpy.uint8)
 
         self.rmt.create_cutout(self.chan, 0, x_rng, y_rng, z_rng, data, time_range=t_rng)
-        self.rmt.create_cutout_to_black(self.chan, 0, x_rng, y_rng, z_rng, data, t_rng)
+        self.rmt.create_cutout_to_black(self.chan, 0, x_rng, y_rng, z_rng, time_range=t_rng)
         actual = self.rmt.get_cutout(self.chan, 0, x_rng, y_rng, z_rng, time_range=t_rng)
         numpy.testing.assert_array_equal(numpy.zeros((3, 5, 4, 8)), actual)
 

--- a/intern/remote/boss/tests/int_test_volume_v1.py
+++ b/intern/remote/boss/tests/int_test_volume_v1.py
@@ -912,5 +912,32 @@ class VolumeServiceTest_v1(unittest.TestCase):
         actual = self.rmt.get_cutout(self.chan, 0, x_rng, y_rng, z_rng, time_range=t_rng)
         numpy.testing.assert_array_equal(data, actual)
 
+    def test_upload_and_cutout_to_black(self):
+        x_rng = [0, 8]
+        y_rng = [0, 4]
+        z_rng = [0, 5]
+
+        data = numpy.random.randint(1, 254, (5, 4, 8))
+        data = data.astype(numpy.uint8)
+
+        self.rmt.create_cutout(self.chan, 0, x_rng, y_rng, z_rng, data)
+        self.rmt.create_cutout_to_black(self.chan, 0, x_rng, y_rng, z_rng)
+        actual = self.rmt.get_cutout(self.chan, 0, x_rng, y_rng, z_rng)
+        numpy.testing.assert_array_equal(numpy.zeros((5,4,8)), actual)
+
+    def test_upload_and_cutout_to_black_with_time(self):
+        x_rng = [0, 8]
+        y_rng = [0, 4]
+        z_rng = [0, 5]
+        t_rng = [3, 6]
+
+        data = numpy.random.randint(1, 254, (3, 5, 4, 8))
+        data = data.astype(numpy.uint8)
+
+        self.rmt.create_cutout(self.chan, 0, x_rng, y_rng, z_rng, data, time_range=t_rng)
+        self.rmt.create_cutout_to_black(self.chan, 0, x_rng, y_rng, z_rng, data, t_rng)
+        actual = self.rmt.get_cutout(self.chan, 0, x_rng, y_rng, z_rng, time_range=t_rng)
+        numpy.testing.assert_array_equal(numpy.zeros((3, 5, 4, 8)), actual)
+
 if __name__ == '__main__':
     unittest.main()

--- a/intern/remote/boss/tests/int_test_volume_v1.py
+++ b/intern/remote/boss/tests/int_test_volume_v1.py
@@ -939,5 +939,25 @@ class VolumeServiceTest_v1(unittest.TestCase):
         actual = self.rmt.get_cutout(self.chan, 0, x_rng, y_rng, z_rng, time_range=t_rng)
         numpy.testing.assert_array_equal(numpy.zeros((3, 5, 4, 8)), actual)
 
+    def test_upload_and_cutout_to_black_partial(self):
+        x_rng = [0, 1024]
+        y_rng = [0, 1024]
+        z_rng = [0, 5]
+
+        x_rng_black = [0, 256]
+        y_rng_black = [0, 512]
+        z_rng_black = [2,3] 
+
+        data = numpy.random.randint(1, 254, (5, 1024, 1024))
+        data = data.astype(numpy.uint8)
+
+        expected = numpy.copy(data)
+        expected[2:3, 0:512, 0:256] = 0
+
+        self.rmt.create_cutout(self.chan, 0, x_rng, y_rng, z_rng, data)
+        self.rmt.create_cutout_to_black(self.chan, 0, x_rng_black, y_rng_black, z_rng_black)
+        actual = self.rmt.get_cutout(self.chan, 0, x_rng, y_rng, z_rng)
+        numpy.testing.assert_array_equal(expected, actual)
+
 if __name__ == '__main__':
     unittest.main()

--- a/intern/service/boss/baseversion.py
+++ b/intern/service/boss/baseversion.py
@@ -209,6 +209,39 @@ class BaseVersion(object):
                 urlWithParams += '{}={}'.format(k,v)
         return urlWithParams
 
+    def build_cutout_to_black_url(
+        self, resource, url_prefix, resolution, x_range, y_range, z_range, time_range=None):
+        """Build the url to access the cutout_to_black function of the Boss' volume service.
+
+        Args:
+            url_prefix (string): Do not end with a slash.  Example of expected value: https://api.theboss.io
+            resolution (int): 0 indicates native resolution.
+            x_range (list[int]): x range such as [10, 20] which means x>=10 and x<20.
+            y_range (list[int]): y range such as [10, 20] which means y>=10 and y<20.
+            z_range (list[int]): z range such as [10, 20] which means z>=10 and z<20.
+            time_range (optional [list[int]]): time range such as [30, 40] which means t>=30 and t<40.
+
+        Returns:
+            (string): Full URL to access API.
+
+        Raises:
+            (RuntimeError): if *_range invalid.
+        """
+        baseUrl = self.build_url(resource, url_prefix, 'cutout/to_black', req_type='cutout')
+        x_rng_lst = self.convert_int_list_range_to_str(x_range)
+        y_rng_lst = self.convert_int_list_range_to_str(y_range)
+        z_rng_lst = self.convert_int_list_range_to_str(z_range)
+
+        urlWithParams = (
+            baseUrl + '/' + str(resolution) + '/' + x_rng_lst + '/' + y_rng_lst +
+            '/' + z_rng_lst + '/')
+
+        if time_range is not None:
+            t_rng_lst = self.convert_int_list_range_to_str(time_range)
+            urlWithParams += t_rng_lst + '/'
+        
+        return urlWithParams
+
     def get_request(self, resource, method, content, url_prefix, token, proj_list_req=False, json=None, data=None):
         """Create a request for accessing the Boss' data model services.
 
@@ -308,6 +341,35 @@ class BaseVersion(object):
             resource, url_prefix, resolution, x_range, y_range, z_range,  time_range, id_list, access_mode)
         headers = self.get_headers(content, token)
         return Request(method, url, headers = headers, data = numpyVolume)
+    
+    def get_cutout_to_black_request(
+        self, resource, method, content, url_prefix, token,
+        resolution, x_range, y_range, z_range, time_range):
+
+        """Create a request for working with cutout_to_black (part of the Boss' volume service).
+
+        Args:
+            resource (intern.resource.boss.BossResource): Resource to perform operation on.
+            method (string): HTTP verb such as 'GET'.
+            content (string): HTTP Content-Type such as 'application/json'.
+            url_prefix (string): protocol + initial portion of URL such as https://api.theboss.io  Do not end with a forward slash.
+            token (string): Django Rest Framework token for auth.
+            resolution (int): 0 indicates native resolution.
+            x_range (list[int]): x range such as [10, 20] which means x>=10 and x<20.
+            y_range (list[int]): y range such as [10, 20] which means y>=10 and y<20.
+            z_range (list[int]): z range such as [10, 20] which means z>=10 and z<20.
+            time_range (list[int]): time range such as [30, 40] which means t>=30 and t<40.
+
+        Returns:
+            (requests.Request): A newly constructed Request object.
+
+        Raises:
+            RuntimeError if url_prefix is None or an empty string.
+        """
+        url = self.build_cutout_to_black_url(
+            resource, url_prefix, resolution, x_range, y_range, z_range,  time_range)
+        headers = self.get_headers(content, token)
+        return Request(method, url, headers = headers)
 
     def get_group_request(self, method, content, url_prefix, token, name=None):
         """Get a request for getting group information.

--- a/intern/service/boss/baseversion.py
+++ b/intern/service/boss/baseversion.py
@@ -212,7 +212,7 @@ class BaseVersion(object):
     def build_cutout_to_black_url(
         self, resource, url_prefix, resolution, x_range, y_range, z_range, time_range=None):
         """Build the url to access the cutout_to_black function of the Boss' volume service.
-
+        TODO: Maybe delete this function and add a base_url parameter to build_cutout_url?
         Args:
             url_prefix (string): Do not end with a slash.  Example of expected value: https://api.theboss.io
             resolution (int): 0 indicates native resolution.

--- a/intern/service/boss/baseversion.py
+++ b/intern/service/boss/baseversion.py
@@ -169,18 +169,18 @@ class BaseVersion(object):
         Raises:
             (RuntimeError): if *_range invalid.
         """
-        baseUrl = self.build_url(resource, url_prefix, 'cutout', req_type='cutout')
+        base_url = self.build_url(resource, url_prefix, 'cutout', req_type='cutout')
         x_rng_lst = self.convert_int_list_range_to_str(x_range)
         y_rng_lst = self.convert_int_list_range_to_str(y_range)
         z_rng_lst = self.convert_int_list_range_to_str(z_range)
 
-        urlWithParams = (
-            baseUrl + '/' + str(resolution) + '/' + x_rng_lst + '/' + y_rng_lst +
+        url_with_params = (
+            base_url + '/' + str(resolution) + '/' + x_rng_lst + '/' + y_rng_lst +
             '/' + z_rng_lst + '/')
 
         if time_range is not None:
             t_rng_lst = self.convert_int_list_range_to_str(time_range)
-            urlWithParams += t_rng_lst + '/'
+            url_with_params += t_rng_lst + '/'
 
         queryParamDict = {}
         if len(id_list) > 0:
@@ -191,23 +191,23 @@ class BaseVersion(object):
             queryParamDict['access-mode'] = access_mode.value 
         """
         TODO: LMR
-        The following could be done using urlib.urlencode(urlWithParams += '?' + urllib.parse.urlencode(queryParamDict,safe=",")),
+        The following could be done using urlib.urlencode(url_with_params += '?' + urllib.parse.urlencode(queryParamDict,safe=",")),
         however urllib's python2 version of this function does not take in the 'safe' parameter and thus we can not use the 
         function interchangable for python2/3. In order to keep our python2/3 compatability, we do not use urllib. 
         """
         if queryParamDict:
             # The first time include '?'
-            urlWithParams += '?'
+            url_with_params += '?'
             for k, v in queryParamDict.items():
                 # if this is the first run through, last char in str will be ?, so don't include '&'
-                if urlWithParams[len(urlWithParams)-1] == '?':
+                if url_with_params[len(url_with_params)-1] == '?':
                     pass
                 # otherwise use '&'
                 else:
-                    urlWithParams += '&'
+                    url_with_params += '&'
                 # Add key and value members
-                urlWithParams += '{}={}'.format(k,v)
-        return urlWithParams
+                url_with_params += '{}={}'.format(k,v)
+        return url_with_params
 
     def build_cutout_to_black_url(
         self, resource, url_prefix, resolution, x_range, y_range, z_range, time_range=None):
@@ -227,20 +227,20 @@ class BaseVersion(object):
         Raises:
             (RuntimeError): if *_range invalid.
         """
-        baseUrl = self.build_url(resource, url_prefix, 'cutout/to_black', req_type='cutout')
+        base_url = self.build_url(resource, url_prefix, 'cutout/to_black', req_type='cutout')
         x_rng_lst = self.convert_int_list_range_to_str(x_range)
         y_rng_lst = self.convert_int_list_range_to_str(y_range)
         z_rng_lst = self.convert_int_list_range_to_str(z_range)
 
-        urlWithParams = (
-            baseUrl + '/' + str(resolution) + '/' + x_rng_lst + '/' + y_rng_lst +
+        url_with_params = (
+            base_url + '/' + str(resolution) + '/' + x_rng_lst + '/' + y_rng_lst +
             '/' + z_rng_lst + '/')
 
         if time_range is not None:
             t_rng_lst = self.convert_int_list_range_to_str(time_range)
-            urlWithParams += t_rng_lst + '/'
+            url_with_params += t_rng_lst + '/'
         
-        return urlWithParams
+        return url_with_params
 
     def get_request(self, resource, method, content, url_prefix, token, proj_list_req=False, json=None, data=None):
         """Create a request for accessing the Boss' data model services.

--- a/intern/service/boss/tests/test_baseversion.py
+++ b/intern/service/boss/tests/test_baseversion.py
@@ -107,10 +107,18 @@ class BaseVersionTest(unittest.TestCase):
         coll = self.chanResource.coll_name
         exp = self.chanResource.exp_name
         chan = self.chanResource.name
-        self.assertEqual(
-            self.url_prefix + '/' + self.test_project.version + '/' +
-            'cutout/to_black/' + coll + '/' + exp + '/' + chan,
-            actual)
+        expected = "/".join(
+            [
+                self.url_prefix,
+                self.test_project.version,
+                "cutout/to_black",
+                coll,
+                exp,
+                chan,
+            ]
+        )
+
+        self.assertEqual(expected, actual)
 
     def test_build_url_normal(self):
         """Test standard use of BaseVersion.build_url().

--- a/intern/service/boss/tests/test_baseversion.py
+++ b/intern/service/boss/tests/test_baseversion.py
@@ -392,12 +392,20 @@ class BaseVersionTest(unittest.TestCase):
             self.chanResource, self.url_prefix,
             res, x_rng_lst, y_rng_lst, z_rng_lst, t_rng_lst)
 
-        self.assertEqual(
-            self.url_prefix + '/' + self.test_volume.version + '/' + self.test_volume.endpoint +
-            '/' + self.chanResource.coll_name + '/' + self.chanResource.exp_name +
-            '/' + self.chanResource.name + '/' + str(res) + '/' + x_range + '/' +
-            y_range + '/' + z_range + '/',
-            actual)
+        expected = '/'.join([
+            self.url_prefix,
+            self.test_volume.version,
+            "cutout/to_black",
+            self.chanResource.coll_name,
+            self.chanResource.exp_name,
+            self.chanResource.name,
+            str(res),
+            x_range,
+            y_range,
+            z_range,
+        ]) + '/'
+
+        self.assertEqual(expected, actual)
 
     def test_build_cutout_url_no_time_range_with_ids(self):
         res = 0
@@ -455,13 +463,22 @@ class BaseVersionTest(unittest.TestCase):
         actual = self.test_volume.build_cutout_to_black_url(
             self.chanResource, self.url_prefix,
             res, x_rng_lst, y_rng_lst, z_rng_lst, t_rng_lst)
+        
+        expected = '/'.join([
+            self.url_prefix,
+            self.test_volume.version,
+            "cutout/to_black",
+            self.chanResource.coll_name,
+            self.chanResource.exp_name,
+            self.chanResource.name,
+            str(res),
+            x_range,
+            y_range,
+            z_range,
+            time_range,
+        ]) + '/'
 
-        self.assertEqual(
-            self.url_prefix + '/' + self.test_volume.version + '/' + self.test_volume.endpoint +
-            '/' + self.chanResource.coll_name + '/' + self.chanResource.exp_name +
-            '/' + self.chanResource.name + '/' + str(res) + '/' + x_range + '/' +
-            y_range + '/' + z_range + '/' + time_range + '/',
-            actual)
+        self.assertEqual(expected, actual)
 
     def test_build_cutout_url_with_time_range_and_ids(self):
         res = 0

--- a/intern/service/boss/tests/test_baseversion.py
+++ b/intern/service/boss/tests/test_baseversion.py
@@ -98,6 +98,20 @@ class BaseVersionTest(unittest.TestCase):
             'cutout/' + coll + '/' + exp + '/' + chan,
             actual)
 
+    def test_build_url_for_cutout_to_black(self):
+        """
+        Test cutout to black URL
+        """
+        actual = self.test_project.build_url(
+        self.chanResource, self.url_prefix, 'cutout/to_black', req_type='cutout')
+        coll = self.chanResource.coll_name
+        exp = self.chanResource.exp_name
+        chan = self.chanResource.name
+        self.assertEqual(
+            self.url_prefix + '/' + self.test_project.version + '/' +
+            'cutout/to_black/' + coll + '/' + exp + '/' + chan,
+            actual)
+
     def test_build_url_normal(self):
         """Test standard use of BaseVersion.build_url().
         """
@@ -364,6 +378,26 @@ class BaseVersionTest(unittest.TestCase):
             '/' + self.chanResource.name + '/' + str(res) + '/' + x_range + '/' +
             y_range + '/' + z_range + '/',
             actual)
+    
+    def test_build_cutout_to_black_url_no_time_range(self):
+        res = 0
+        x_rng_lst = [20, 40]
+        x_range = '20:40'
+        y_rng_lst = [50, 70]
+        y_range = '50:70'
+        z_rng_lst = [30, 50]
+        z_range = '30:50'
+        t_rng_lst = None
+        actual = self.test_volume.build_cutout_to_black_url(
+            self.chanResource, self.url_prefix,
+            res, x_rng_lst, y_rng_lst, z_rng_lst, t_rng_lst)
+
+        self.assertEqual(
+            self.url_prefix + '/' + self.test_volume.version + '/' + self.test_volume.endpoint +
+            '/' + self.chanResource.coll_name + '/' + self.chanResource.exp_name +
+            '/' + self.chanResource.name + '/' + str(res) + '/' + x_range + '/' +
+            y_range + '/' + z_range + '/',
+            actual)
 
     def test_build_cutout_url_no_time_range_with_ids(self):
         res = 0
@@ -398,6 +432,27 @@ class BaseVersionTest(unittest.TestCase):
         t_rng_lst = [10, 25]
         time_range = '10:25'
         actual = self.test_volume.build_cutout_url(
+            self.chanResource, self.url_prefix,
+            res, x_rng_lst, y_rng_lst, z_rng_lst, t_rng_lst)
+
+        self.assertEqual(
+            self.url_prefix + '/' + self.test_volume.version + '/' + self.test_volume.endpoint +
+            '/' + self.chanResource.coll_name + '/' + self.chanResource.exp_name +
+            '/' + self.chanResource.name + '/' + str(res) + '/' + x_range + '/' +
+            y_range + '/' + z_range + '/' + time_range + '/',
+            actual)
+
+    def test_build_cutout_to_black_url_with_time_range(self):
+        res = 0
+        x_rng_lst = [20, 40]
+        x_range = '20:40'
+        y_rng_lst = [50, 70]
+        y_range = '50:70'
+        z_rng_lst = [30, 50]
+        z_range = '30:50'
+        t_rng_lst = [10, 25]
+        time_range = '10:25'
+        actual = self.test_volume.build_cutout_to_black_url(
             self.chanResource, self.url_prefix,
             res, x_rng_lst, y_rng_lst, z_rng_lst, t_rng_lst)
 

--- a/intern/service/boss/v1/volume.py
+++ b/intern/service/boss/v1/volume.py
@@ -128,6 +128,58 @@ class VolumeService_1(BaseVersion):
             resource.name, resp.status_code, resp.text))
         raise HTTPError(msg, request=req, response=resp)
 
+    def create_cutout_to_black(
+        self, resource, resolution, x_range, y_range, z_range, time_range, url_prefix, 
+        auth, session, send_opts):
+        """Upload a black cutout to the Boss data store.
+
+        Args:
+            resource (intern.resource.resource.Resource): Resource compatible with cutout operations.
+            resolution (int): 0 indicates native resolution.
+            x_range (list[int]): x range such as [10, 20] which means x>=10 and x<20.
+            y_range (list[int]): y range such as [10, 20] which means y>=10 and y<20.
+            z_range (list[int]): z range such as [10, 20] which means z>=10 and z<20.
+            time_range (optional [list[int]]): time range such as [30, 40] which means t>=30 and t<40.
+            url_prefix (string): Protocol + host such as https://api.theboss.io
+            auth (string): Token to send in the request header.
+            session (requests.Session): HTTP session to use for request.
+            send_opts (dictionary): Additional arguments to pass to session.send().
+        """
+
+        # Check to see if this volume is larger than 1GB. If so, chunk it into
+        # several smaller bites:
+        if (
+                (x_range[1] - x_range[0]) *
+                (y_range[1] - y_range[0]) *
+                (z_range[1] - z_range[0])
+        ) > 1024 * 1024 * 32 * 2:
+            blocks = block_compute(
+                x_range[0], x_range[1],
+                y_range[0], y_range[1],
+                z_range[0], z_range[1],
+                block_size=(1024, 1024, 32)
+            )
+            for b in blocks:
+                self.create_cutout_to_black(
+                    resource, resolution, b[0], b[1], b[2],
+                    time_range, url_prefix, auth, session, send_opts
+                )
+            return
+
+        req = self.get_cutout_to_black_request(
+            resource, 'PUT', 'application/blosc',
+            url_prefix, auth,
+            resolution, x_range, y_range, z_range, time_range)
+        prep = session.prepare_request(req)
+        resp = session.send(prep, **send_opts)
+
+        if resp.status_code == 200:
+            return
+
+        msg = ('Create cutout_to_black failed on {}, got HTTP response: ({}) - {}'.format(
+            resource.name, resp.status_code, resp.text))
+        raise HTTPError(msg, request=req, response=resp)
+
     def get_cutout(
             self, resource, resolution, x_range, y_range, z_range, time_range, id_list,
             url_prefix, auth, session, send_opts, access_mode=CacheMode.no_cache, parallel: bool = True, **kwargs

--- a/intern/service/boss/volume.py
+++ b/intern/service/boss/volume.py
@@ -81,6 +81,25 @@ class VolumeService(BossService):
             self.url_prefix, self.auth, self.session, self.session_send_opts)
 
     @check_channel
+    def create_cutout_to_black(
+        self, resource, resolution, x_range, y_range, z_range, time_range=None):
+        """Upload a black cutout to the volume service.
+
+        Args:
+            resource (intern.resource.Resource): Resource compatible with cutout operations.
+            resolution (int): 0 indicates native resolution.
+            x_range (list[int]): x range such as [10, 20] which means x>=10 and x<20.
+            y_range (list[int]): y range such as [10, 20] which means y>=10 and y<20.
+            z_range (list[int]): z range such as [10, 20] which means z>=10 and z<20.
+            time_range (optional [list[int]]): time range such as [30, 40] which means t>=30 and t<40.
+        """
+
+
+        return self.service.create_cutout_to_black(
+            resource, resolution, x_range, y_range, z_range, time_range,
+            self.url_prefix, self.auth, self.session, self.session_send_opts)
+
+    @check_channel
     def get_cutout(self, resource, resolution, x_range, y_range, z_range, time_range=None, id_list=[], access_mode=CacheMode.no_cache, **kwargs):
         """Get a cutout from the volume service.
 


### PR DESCRIPTION
Adds necessary remote functions and tests to utilize the bossDB cutout_to_black API call. With this addition, users can now upload black tiles easily without having to use ingest client.

Remote function call:
```python
BossRemote.create_cutout_to_black(resource, resolution, x_range, y_range, z_range, t_range)
```
