### PR TITLE
[Convenience API] Add source_channel option for annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ---
 
+## v1.1.0 — July 27 2020
+
+> Updates to the convenience API.
+
+-   **Convenience API**
+    -   New arguments to specify the source channel for annotation channels
+    -   Specify BossDB config inline without special imports with `array(..., boss_config: dict)` argument
+    -   Specify descriptions for newly created resources when calling `array(..., create_new=True)`.
+
 ## v1.0.0 — June 1, 2020
 
 > This version introduces the convenience API which uses numpy-like indexing.
@@ -11,7 +20,7 @@ This build switches `intern` CI to GitHub actions, and now tests both 3.6 as wel
 ### Features
 
 -   **Convenience API** (#48)
-    -   This adds support for the simple `intern.array` interface which mocks the numpy array for getters and setters.
+    -   This adds support for the simple `intern.array` interface which mocks the numpy array API for getters and setters.
 -   Add support for DVID and cloud-volume hosted data with `DVIDRemote` and `CloudVolumeRemote`. (#46)
 -   Add parallelism to `BossRemote#get_cutout` calls by passing `parallel=True` or `parallel=<int # of jobs>` as an argument. (#52)
 -   Addition of a `MeshService` for local meshing of 3D segmentation data.

--- a/intern/convenience/array.py
+++ b/intern/convenience/array.py
@@ -22,9 +22,6 @@ from collections import namedtuple
 # Pip-installable imports
 import numpy as np
 
-import blosc
-import requests
-
 from intern.resource.boss.resource import (
     CollectionResource,
     ChannelResource,
@@ -144,7 +141,7 @@ def parse_bossdb_uri(uri: str) -> bossdbURI:
     Parse a bossDB URI and handle malform errors.
 
     Arguments:
-        uri (str): URI of the form bossdb://<collection/<experiment/<channel>
+        uri (str): URI of the form bossdb://<collection>/<experiment>/<channel>
 
     Returns:
         bossdbURI

--- a/intern/convenience/array.py
+++ b/intern/convenience/array.py
@@ -200,6 +200,8 @@ class array:
         coordinate_frame_desc: Optional[str] = None,
         collection_desc: Optional[str] = None,
         experiment_desc: Optional[str] = None,
+        source_channel: Optional[str] = None,
+        base_resolution: Optional[int] = 0,
         boss_config: Optional[dict] = None,
     ) -> None:
         """
@@ -243,6 +245,11 @@ class array:
             experiment_desc (Optional[str]): The description text to use for a
                 newly created experiment. If not set, the description will be
                 chosen automatically.
+            source_channel (Optional[str]): The channel to use as the source
+                for this new channel, if `create_new` is True and this is
+                going to be an annotation channel (dtype!=uint8).
+            base_resolution (Optional[int]): The base resolution to set for the
+                newly created channel, if `create_new` is True.
             boss_config (Optional[dict]): The BossRemote configuration dict to
                 use in order to authenticate with a BossDB remote. This option
                 is mutually exclusive with the VolumeProvider configuration. If
@@ -348,6 +355,8 @@ class array:
                     description=description,
                     type="image" if dtype == "uint8" else "annotation",
                     datatype=dtype,
+                    base_resolution=base_resolution,
+                    sources=[source_channel] if source_channel else [],
                 )
                 self.volume_provider.create_project(channel)
 

--- a/intern/convenience/array.py
+++ b/intern/convenience/array.py
@@ -201,7 +201,6 @@ class array:
         collection_desc: Optional[str] = None,
         experiment_desc: Optional[str] = None,
         source_channel: Optional[str] = None,
-        base_resolution: Optional[int] = 0,
         boss_config: Optional[dict] = None,
     ) -> None:
         """
@@ -248,8 +247,6 @@ class array:
             source_channel (Optional[str]): The channel to use as the source
                 for this new channel, if `create_new` is True and this is
                 going to be an annotation channel (dtype!=uint8).
-            base_resolution (Optional[int]): The base resolution to set for the
-                newly created channel, if `create_new` is True.
             boss_config (Optional[dict]): The BossRemote configuration dict to
                 use in order to authenticate with a BossDB remote. This option
                 is mutually exclusive with the VolumeProvider configuration. If
@@ -355,7 +352,6 @@ class array:
                     description=description,
                     type="image" if dtype == "uint8" else "annotation",
                     datatype=dtype,
-                    base_resolution=base_resolution,
                     sources=[source_channel] if source_channel else [],
                 )
                 self.volume_provider.create_project(channel)


### PR DESCRIPTION
Annotation channels require a `source_channel` to be specified at creation-time. This enables the convenience-API array() constructor to create annotation channels (`uint16` and `uint64` segmentation).

## Usage

```python
from intern import array

array(
    "bossdb://collection/experiment/segmentation",
    create_new=True,
    dtype="uint64",
    source_channel="image" # refers to "bossdb://collection/experiment/image"
)
```

When creating an annotation channel in an existing experiment, coordinate-frame information is not required (`voxel_size`, `voxel_units`, `extents`) since the collection, experiment, and coordinate-frame will already exist.