### PR TITLE
Fix pip-installability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ---
 
-## v1.1.0 — July 27 2020
+## v1.1.1 — September 2, 2020
+
+> Pip-installability fix (#67).
+
+## v1.1.0 — July 27, 2020
 
 > Updates to the convenience API.
 

--- a/intern/__init__.py
+++ b/intern/__init__.py
@@ -4,22 +4,4 @@ A Python library for open neuroscience data access and manipulation.
 
 from .convenience import array
 
-__version__ = "1.0.0"
-
-
-def check_version():
-    """
-    Tells you if you have an old version of intern.
-    """
-    import requests
-
-    r = requests.get("https://pypi.python.org/pypi/intern/json").json()
-    r = r["info"]["version"]
-    if r != __version__:
-        print(
-            "You are using version {}. A newer version of intern is available: {} ".format(
-                __version__, r
-            )
-            + "\n\n'pip install -U intern' to update."
-        )
-    return r
+from .version import __version__, check_version

--- a/intern/version/__init__.py
+++ b/intern/version/__init__.py
@@ -1,5 +1,4 @@
-
-__version__ = "1.0.0"
+__version__ = "1.1.1"
 
 
 def check_version():

--- a/intern/version/__init__.py
+++ b/intern/version/__init__.py
@@ -1,0 +1,20 @@
+
+__version__ = "1.0.0"
+
+
+def check_version():
+    """
+    Tells you if you have an old version of intern.
+    """
+    import requests
+
+    r = requests.get("https://pypi.python.org/pypi/intern/json").json()
+    r = r["info"]["version"]
+    if r != __version__:
+        print(
+            "You are using version {}. A newer version of intern is available: {} ".format(
+                __version__, r
+            )
+            + "\n\n'pip install -U intern' to update."
+        )
+    return r

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ six
 mock
 nose2
 zmesh
-enum34
 
 # cloud-volume
 brotli

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,14 @@
 from setuptools import setup, find_packages
 from codecs import open
 from os import path
-from intern import __version__
+import os.path
 
 # to update
+# Update intern.version.__version__, update __version__ below:
 # python setup.py sdist
 # twine upload dist/*
 
+__version__ = "1.0.0"
 
 here = path.abspath(path.dirname(__file__))
 

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,8 @@ def get_version(rel_path):
         if line.startswith("__version__"):
             delim = '"' if '"' in line else "'"
             return line.split(delim)[1]
+        else:
+            raise RuntimeError("Unable to find version string.")
 
 
 __version__ = get_version("intern/version/__init__.py")

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import os.path
 # python setup.py sdist
 # twine upload dist/*
 
-__version__ = "1.0.0"
+__version__ = "1.1.1"
 
 here = path.abspath(path.dirname(__file__))
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,24 @@ import os.path
 # python setup.py sdist
 # twine upload dist/*
 
-__version__ = "1.1.1"
+import codecs
+import os.path
+
+
+def read(rel_path):
+    here = os.path.abspath(os.path.dirname(__file__))
+    with codecs.open(os.path.join(here, rel_path), "r") as fp:
+        return fp.read()
+
+
+def get_version(rel_path):
+    for line in read(rel_path).splitlines():
+        if line.startswith("__version__"):
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+
+
+__version__ = get_version("intern/version/__init__.py")
 
 here = path.abspath(path.dirname(__file__))
 


### PR DESCRIPTION
We were importing from `intern` before it was installed (to get `version` in the root of the package), which to the best of my understanding has fallen out of favor as a way of checking the package version. This is a nonbreaking, backwards-compatible change.