### PR TITLE
Set cloudvolume prerequisite as optional extra instead of always required.  

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ For example, on a \*nix system, if intern was cloned to ~/intern:
 
 > **For Python 2 support, you will need to install intern v0.10.0 or earlier.**
 
+### Optional Dependencies
+To install depedencies required to use the [cloud-volume](https://github.com/seung-lab/cloud-volume) remote, run the command: 
+
+```shell
+pip install intern[cloudvolume]
+```
+
 ## Getting Started
 
 To quickly get started with intern, check out the wiki: [https://github.com/jhuapl-boss/intern/wiki](https://github.com/jhuapl-boss/intern/wiki)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,3 @@ six
 mock
 nose2
 zmesh
-
-# cloud-volume
-brotli
-cloud-volume>=1.6.0

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,12 @@ setup(
     include_package_data=True,
     author="Johns Hopkins University Applied Physics Laboratory",
     install_requires=install_requires,
+    extras_require={
+        "cloudvolume":[
+            "cloud-volume>=3.4.0",
+            "brotli>=1.0.7"
+        ]
+    },
     dependency_links=dependency_links,
     author_email="iarpamicrons@jhuapl.edu",
 )


### PR DESCRIPTION
Currently the intern install takes longer than it needs to due to having to install cloud-volume which has its own large set of prerequisites. 

I propose we change cloud-volume as an optional extra that can be installed if the user plans on using the cloud-volume remote. The install line would be as follows:

`pip install intern[cloudvolume]`