### PR TITLE
Optimize chunk_size Parameter and Array Construction

### DIFF
--- a/intern/service/boss/v1/volume.py
+++ b/intern/service/boss/v1/volume.py
@@ -223,10 +223,10 @@ class VolumeService_1(BaseVersion):
             # USUALLY is the fastest. There is some variabiity on number of threads. 
             chunk_size = kwargs.pop("chunk_size", (512, 512, 16 * 6))
         else:
-            # Single thread downloads are faster with a large chunk size, but can't surpass 500 MB limit. 
-            # To stay within 500 MB constraint with 64-bit data, we chose a chunk size of (512, 512, 128) 
-            # which is about 268 MB. The chunk limit is therefore ~320 MB. 
-            chunk_size = kwargs.pop("chunk_size", (512, 512, 16 * 8))
+            # Single thread downloads are faster with a large chunk size, but can't surpass 
+            # 500 MB limit. To stay within 500 MB constraint with 64-bit data, we chose a 
+            # chunk size of (512, 512, 192) which is about 402 MB. 
+            chunk_size = kwargs.pop("chunk_size", (512, 512, 16 * 12))
         
         # TODO: magic number
         chunk_limit = (chunk_size[0] * chunk_size[1] * chunk_size[2]) * 1.2

--- a/intern/service/boss/v1/volume.py
+++ b/intern/service/boss/v1/volume.py
@@ -217,7 +217,17 @@ class VolumeService_1(BaseVersion):
         Raises:
             requests.HTTPError
         """
-        chunk_size = kwargs.pop("chunk_size", (512, 512, 16 * 8))
+        if parallel:
+            # Parallel downloads are faster with a smaller chunk size but can easily overwhelm
+            # the endpoint if its too small. Therefore from empirical testing (512, 512, 96) 
+            # USUALLY is the fastest. There is some variabiity on number of threads. 
+            chunk_size = kwargs.pop("chunk_size", (512, 512, 16 * 6))
+        else:
+            # Single thread downloads are faster with a large chunk size, but can't surpass 500 MB limit. 
+            # To stay within 500 MB constraint with 64-bit data, we chose a chunk size of (512, 512, 128) 
+            # which is about 268 MB. The chunk limit is therefore ~320 MB. 
+            chunk_size = kwargs.pop("chunk_size", (512, 512, 16 * 8))
+        
         # TODO: magic number
         chunk_limit = (chunk_size[0] * chunk_size[1] * chunk_size[2]) * 1.2
 
@@ -303,7 +313,7 @@ class VolumeService_1(BaseVersion):
 
         if resp.status_code == 200:
             raw_data = blosc.decompress(resp.content)
-            data_mat = np.fromstring(raw_data, dtype=resource.datatype)
+            data_mat = np.frombuffer(raw_data, dtype=resource.datatype)
 
             if time_range:
                 # Reshape including time


### PR DESCRIPTION
From downloading testing, `chunk_size` and the NumPy array construction significantly affected the overall speed of downloading cutouts. After some empirical testing I settled on some default values that will increase speed for typical download sizes. 

I also changed the array initialization to use `np.frombuffer` instead of `np.fromstring`. This is like some insane 62,000% increase in performance but in reality just cuts a couple milliseconds :)
 
![Screen Shot 2021-02-09 at 6 42 14 PM](https://user-images.githubusercontent.com/39000785/107443290-91801c00-6b06-11eb-8321-a70709da90c2.png)
