### PR TITLE
Add neuroglancer convenience methods

### DIFF
--- a/intern/convenience/uri.py
+++ b/intern/convenience/uri.py
@@ -98,3 +98,7 @@ def parse_fquri(fully_qualified_uri, **kwargs):
 
         resource = remote.get_channel(channel, collection, experiment)
         return (remote, resource)
+    raise InvalidURIError(
+        "BossDB URIs must be of the form bossdb://http[s]://[host]/[collection]/[experiment]/[echannel], got "
+        + remote_path
+    )


### PR DESCRIPTION
### `volumes_from_neuroglancer`

```python
from intern.convenience import volumes_from_neuroglancer

vols = volumes_from_neuroglancer("https://neuroglancer.bossdb.io/#! ... ")
```

This returns a dictionary where keys correspond to channel names in the neuroglancer page and arrays correspond to a volume of data around the center of the field of view from that URL. The optional parameter `radius_zyx` may be specified (`Tuple[int, int, int]`) to download a different shape of data.

### `arrays_from_neuroglancer`

```python
from intern.convenience import arrays_from_neuroglancer

datasets = arrays_from_neuroglancer("https://neuroglancer.bossdb.io/#! ... ")
```

This returns a dictionary where instead of volumes of data, `intern.array` objects are returned, which point to the channels from the neuroglancer URL.