### PR TITLE
Feature: cuboids-from-id

### DIFF
--- a/intern/remote/remote.py
+++ b/intern/remote/remote.py
@@ -313,3 +313,21 @@ class Remote(object):
             volume, x_range, y_range, z_range, time_range, id_list, voxel_unit, voxel_size,
             simp_fact, max_simplification_error, normals)
         return mesh
+
+    def get_cuboids_from_id(self, resource, resolution, id):
+        """Get corners for cuboids that belong to a specific ID. 
+
+        All returned corners are cuboid aligned.
+
+        Args:
+            resource (intern.resource.Resource): Resource compatible with annotation operations.
+            resolution (int): 0 indicates native resolution.
+            id (int): Id of object of interest.
+
+        Returns:
+            (dict): {'cuboids': [[512, 512, 64], [0, 512, 32], [512, 512, 32], [0, 512, 48]]}
+        """
+        if not resource.valid_volume():
+            raise RuntimeError('Resource incompatible with the volume service.')
+
+        return self._volume.get_cuboids_from_id(resource, resolution, id)

--- a/intern/service/boss/baseversion.py
+++ b/intern/service/boss/baseversion.py
@@ -673,3 +673,31 @@ class BaseVersion(object):
             resource, url_prefix, resolution, x_range, y_range, z_range, time_range)
         headers = self.get_headers(content, token)
         return Request(method, url, headers=headers)
+
+    def get_cuboids_from_id_request(
+            self, resource, method, content, url_prefix, token, resolution, id):
+        """Create a request for cuboids_from_id endpoint. 
+
+        Args:
+            resource (intern.resource.boss.BossResource): Resource to perform operation on.
+            method (string): HTTP verb such as 'GET'.
+            content (string): HTTP Content-Type such as 'application/json'.
+            url_prefix (string): protocol + initial portion of URL such as https://api.theboss.io  Do not end with a forward slash.
+            token (string): Django Rest Framework token for auth.
+            resolution (int): 0 = default resolution.
+            id (int): Annotation object id.
+
+        Returns:
+            (requests.Request): A newly constructed Request object.
+
+        Raises:
+            RuntimeError if url_prefix is None or an empty string.
+        """
+        if url_prefix is None or url_prefix == '':
+            raise RuntimeError('url_prefix required.')
+
+        url = (url_prefix + '/' + self.version + '/cuboidsfromid/' +
+               resource.get_cutout_route() + '/{}/{}'.format(
+            resolution, id))
+        headers = self.get_headers(content, token)
+        return Request(method, url, headers=headers)

--- a/intern/service/boss/v1/volume.py
+++ b/intern/service/boss/v1/volume.py
@@ -485,3 +485,45 @@ class VolumeService_1(BaseVersion):
         """
         link = "https://neuroglancer.theboss.io/#!{'layers':{'" + str(resource.name)   + "':{'type':'" + resource.type + "'_'source':" + "'boss://" + url_prefix+ "/" + resource.coll_name + "/" + resource.exp_name + "/" + resource.name + "'}}_'navigation':{'pose':{'position':{'voxelCoordinates':[" + str(x_range[0]) + "_" + str(y_range[0]) + "_" + str(z_range[0]) + "]}}}}"
         return link
+
+    def get_cuboids_from_id(
+            self, resource, resolution, _id, url_prefix, auth, session, send_opts):
+        """Get corners for cuboids that belong to a specific ID.
+
+        All returned corners are cuboid aligned.
+
+        Args:
+            resource (intern.resource.Resource): Resource compatible with annotation operations.
+            resolution (int): 0 indicates native resolution.
+            _id (int): Id of object of interest.
+            url_prefix (string): Protocol + host such as https://api.theboss.io
+            auth (string): Token to send in the request header.
+            session (requests.Session): HTTP session to use for request.
+            send_opts (dictionary): Additional arguments to pass to session.send().
+
+        Returns:
+            (dict): {'cuboids': [[512, 512, 64], [0, 512, 32], [512, 512, 32], [0, 512, 48]]}
+
+        Raises:
+            requests.HTTPError
+            TypeError: if resource is not an annotation channel.
+        """
+        if not isinstance(resource, ChannelResource):
+            raise TypeError('resource must be ChannelResource')
+        if resource.type != 'annotation':
+            raise TypeError('Channel is not an annotation channel')
+
+        req = self.get_cuboids_from_id_request(
+            resource, 'GET', 'application/json', url_prefix, auth, resolution,
+            _id)
+
+        prep = session.prepare_request(req)
+        resp = session.send(prep, **send_opts)
+
+        if resp.status_code == 200:
+            json_data = resp.json()
+            return json_data
+
+        msg = ('Get bounding box failed on {}, got HTTP response: ({}) - {}'.format(
+            resource.name, resp.status_code, resp.text))
+        raise HTTPError(msg, request=req, response=resp)

--- a/intern/service/boss/volume.py
+++ b/intern/service/boss/volume.py
@@ -212,3 +212,21 @@ class VolumeService(BossService):
             Other exceptions may be raised depending on the volume service's implementation.
         """
         return self.service.get_neuroglancer_link(resource, resolution, x_range, y_range, z_range, self.url_prefix, **kwargs)
+    
+    @check_channel
+    def get_cuboids_from_id(self, resource, resolution, id):
+        """Get corners for cuboids that belong to a specific ID.
+
+        All returned corners are cuboid aligned.
+
+        Args:
+            resource (intern.resource.Resource): Resource compatible with annotation operations.
+            resolution (int): 0 indicates native resolution.
+            id (int): Id of object of interest.
+
+        Returns:
+            (dict): {'cuboids': [[512, 512, 64], [0, 512, 32], [512, 512, 32], [0, 512, 48]]}
+        """
+        return self.service.get_cuboids_from_id(
+            resource, resolution, id,
+            self.url_prefix, self.auth, self.session, self.session_send_opts)


### PR DESCRIPTION
Adds remote function for the `cuboidsfromid` api in bossDB. It is now possible to get a list of cuboids that belong to a specific annotation ID. Remote syntax is as follows:
```python

rmt = BossRemote()
resource = rmt.get_channel('foo', 'bar', 'baz')
rmt.get_cuboids_from_id(resource, resolution=0, id='18203028421')

```

```python
>> {'cuboids': [[512, 512, 64],
  [0, 512, 32],
  [512, 512, 32],
  [0, 512, 48],
  [512, 512, 48]]}
```