### PR TITLE
Fix voxel units get/set

### DIFF
--- a/intern/convenience/array.py
+++ b/intern/convenience/array.py
@@ -303,6 +303,8 @@ class array:
                     )
                 )
             except:
+                # Default to nanometers if a voxel unit isn't provided
+                voxel_unit = voxel_unit or "nanometers"
                 # Create the coordframe:
                 coordframe = CoordinateFrameResource(
                     coordinate_frame_name or f"CF_{uri.collection}_{uri.experiment}",
@@ -486,7 +488,13 @@ class array:
                 self._coord_frame.y_voxel_size,
                 self._coord_frame.x_voxel_size,
             )
-        return (vox_size, self._coord_frame.voxel_unit)
+        return vox_size
+
+    @property
+    def voxel_unit(self):
+        if self._coord_frame is None:
+            self._populate_coord_frame()
+        return self._coord_frame.voxel_unit
 
     def _populate_exp(self):
         """
@@ -504,6 +512,8 @@ class array:
 
         Cache the results for later.
         """
+        if self._exp is None:
+            self._populate_exp()
         self._coord_frame = self.volume_provider.get_project(
             CoordinateFrameResource(self._exp.coord_frame)
         )


### PR DESCRIPTION
When creating a new intern.array, `voxel_units` defaults to `nanometers` (like it says it does in the docs) instead of failing with an HTTP error (because of a blank `voxel_units` field).

When asking for `voxel_size`, you now get a tuple of floats, to parallel what the user provides as a function arg (instead of a tuple of voxel size and voxel units). This PR also adds a NEW property fn called `voxel_unit` which returns the voxel unit used by the channel so that this information remains available.