### PR TITLE
meshing now under extras_require

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install -e .[brotli,cloud-volume,zmesh]
+        pip install -e .[cloudvolume,meshing]
 #     - name: Lint with flake8
 #       run: |
 #         pip install flake8

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,7 @@ jobs:
         pip install -r requirements.txt
         pip install brotli>=1.0.7
         pip install cloud-volume>=3.4.0
+        pip install zmesh>=0.5.0
 #     - name: Lint with flake8
 #       run: |
 #         pip install flake8

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -26,9 +26,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install brotli>=1.0.7
-        pip install cloud-volume>=3.4.0
-        pip install zmesh>=0.5.0
+        pip install -e .[brotli,cloud-volume,zmesh]
 #     - name: Lint with flake8
 #       run: |
 #         pip install flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ blosc>=1.4.4
 six
 mock
 nose2
-zmesh

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
     include_package_data=True,
     author="Johns Hopkins University Applied Physics Laboratory",
     install_requires=install_requires,
-    extras_require={'cloudvolume': ['cloud-volume>=3.4.0', 'brotli>=1.0.7'],'meshing': ['zmesh']},
+    extras_require={'cloudvolume': ['cloud-volume>=3.4.0', 'brotli>=1.0.7'],'meshing': ['zmesh>=0.5.0']},
     dependency_links=dependency_links,
     author_email="iarpamicrons@jhuapl.edu",
 )

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
     include_package_data=True,
     author="Johns Hopkins University Applied Physics Laboratory",
     install_requires=install_requires,
-    extras_require={"cloudvolume": ["cloud-volume>=3.4.0", "brotli>=1.0.7"]},
+    extras_require={'cloudvolume': ['cloud-volume>=3.4.0', 'brotli>=1.0.7'],'meshing': ['zmesh']},
     dependency_links=dependency_links,
     author_email="iarpamicrons@jhuapl.edu",
 )


### PR DESCRIPTION
Tested install on python 3.6.14, 3.7.11, 3.8.11, 3.9.5, 3.9.6 for both general intern and intern['meshing'].