### PR TITLE
Remove Python 3.6 from GitHub Actions tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Python 3.6 [EOL'd on 23 Dec 2021](https://endoflife.date/python). There are a few things in 3.6 that have been keeping us from using the latest features of Python, so I'm making this PR to discuss removing it from our test suite and keeping the intern codebase up to the latest SotA!