### PR TITLE
Add a metadata interface for all boss resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     -   Adds a `array().downsampled` property on the convenience API (#84)
     -   Fixes voxel_unit getters and setters to be more consistent with convenience API constructor (#83)
     -   Adds data-source inference to redirect requests to the correct `Remote` (#91)
+    -   Adds a metadata interface `Metadata()` for general metadata read/write access (#92)
 -   **Improvements**
     -   Adds a `BossResource.public` boolean flag to mirror if a resource is publicly accessible (#89)
 -   **Fixes**
@@ -24,10 +25,10 @@
 -   **Parallelism**
     -   Fixes parallelism defaulting to n=1 (#70)
 -   **CloudVolume**
-    - Removes cloudvolume core dependency, and makes it an optional extra-install (#68)
-- **Fixes and Improvements**
-    - Adds support for the new "queued" downsample channel status (#78)
-    - Adds support for z-index slicing in the convenience array API (#77)
+    -   Removes cloudvolume core dependency, and makes it an optional extra-install (#68)
+-   **Fixes and Improvements**
+    -   Adds support for the new "queued" downsample channel status (#78)
+    -   Adds support for z-index slicing in the convenience array API (#77)
 
 ## v1.1.1 — September 2, 2020
 

--- a/intern/resource/boss/resource.py
+++ b/intern/resource/boss/resource.py
@@ -144,7 +144,7 @@ class CollectionResource(BossResource):
         return self.name
 
     def get_list_route(self):
-        return ''
+        return self.name + "/"
 
     def get_cutout_route(self):
         raise RuntimeError('Not supported for collections.')
@@ -173,7 +173,7 @@ class ExperimentResource(BossResource):
     """
     def __init__(self, name, collection_name, coord_frame='', description='',
         num_hierarchy_levels=1, hierarchy_method='anisotropic',
-        num_time_samples=1, creator='', raw={}, 
+        num_time_samples=1, creator='', raw={},
         time_step=0, time_step_unit='seconds'):
         """Constructor.
 
@@ -436,9 +436,9 @@ class ChannelResource(BossResource):
         """Constructor.
 
         Note, if the channel _already_ exists in the Boss, you can use the
-        helper method get_channel(), that is part of BossRemote, to 
+        helper method get_channel(), that is part of BossRemote, to
         instantiate the ChannelResource with all the correct values, using only
-        the names of the collection, experiment, and channel.  
+        the names of the collection, experiment, and channel.
 
         rmt = BossRemote()
         channel = rmt.get_channel('myChannel', 'myCollection', 'myExperiment')

--- a/intern/resource/boss/tests/test_collection.py
+++ b/intern/resource/boss/tests/test_collection.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
+﻿# Copyright 2022 The Johns Hopkins University Applied Physics Laboratory
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,9 +15,10 @@
 import unittest
 from intern.resource.boss.resource import CollectionResource
 
+
 class TestCollectionResource(unittest.TestCase):
     def setUp(self):
-        self.coll = CollectionResource('foo')
+        self.coll = CollectionResource("foo")
 
     def test_not_valid_volume(self):
         self.assertFalse(self.coll.valid_volume())
@@ -26,4 +27,4 @@ class TestCollectionResource(unittest.TestCase):
         self.assertEqual(self.coll.name, self.coll.get_route())
 
     def test_get_list_route(self):
-        self.assertEqual('', self.coll.get_list_route())
+        self.assertEqual("foo/", self.coll.get_list_route())

--- a/intern/service/boss/tests/test_baseversion.py
+++ b/intern/service/boss/tests/test_baseversion.py
@@ -269,7 +269,7 @@ class BaseVersionTest(unittest.TestCase):
         actual = self.test_project.get_user_request(
             'POST', 'application/json', url_prefix, token, user, email=email)
 
-    def test_get_user_request_with_password_and_email(self):
+    def test_get_user_request_with_password_and_user(self):
         url_prefix = 'https://api.theboss.io'
         token = 'foobar'
         user = 'fire'
@@ -286,7 +286,7 @@ class BaseVersionTest(unittest.TestCase):
         self.assertEqual(expected, actual.url)
         self.assertDictEqual(expectedData, actual.json)
 
-    def test_get_user_request_with_password(self):
+    def test_get_user_request_with_password_and_email(self):
         url_prefix = 'https://api.theboss.io'
         token = 'foobar'
         user = 'fire'

--- a/intern/service/boss/tests/test_baseversion.py
+++ b/intern/service/boss/tests/test_baseversion.py
@@ -83,7 +83,7 @@ class BaseVersionTest(unittest.TestCase):
             self.resource, self.url_prefix, 'collection', req_type='list')
         self.assertEqual(
             self.url_prefix + '/' + self.test_project.version + '/' +
-            self.test_project.endpoint + '/',
+            self.test_project.endpoint + '/' + self.resource.name + '/',
             actual)
 
     def test_build_url_for_cutout(self):
@@ -269,7 +269,7 @@ class BaseVersionTest(unittest.TestCase):
         actual = self.test_project.get_user_request(
             'POST', 'application/json', url_prefix, token, user, email=email)
 
-    def test_get_user_request_with_password(self):
+    def test_get_user_request_with_password_and_email(self):
         url_prefix = 'https://api.theboss.io'
         token = 'foobar'
         user = 'fire'
@@ -386,7 +386,7 @@ class BaseVersionTest(unittest.TestCase):
             '/' + self.chanResource.name + '/' + str(res) + '/' + x_range + '/' +
             y_range + '/' + z_range + '/',
             actual)
-    
+
     def test_build_cutout_to_black_url_no_time_range(self):
         res = 0
         x_rng_lst = [20, 40]
@@ -471,7 +471,7 @@ class BaseVersionTest(unittest.TestCase):
         actual = self.test_volume.build_cutout_to_black_url(
             self.chanResource, self.url_prefix,
             res, x_rng_lst, y_rng_lst, z_rng_lst, t_rng_lst)
-        
+
         expected = '/'.join([
             self.url_prefix,
             self.test_volume.version,


### PR DESCRIPTION
This adds a `Metadata` convenience class to navigate the BossDB project hierarchy:

```python
from intern.convenience import Metadata

m = Metadata("microns")

# Traverse with "/" operator:
mp = m / "pinky100" # same as `Metadata("microns/pinky100")`
```

The `Metadata` class pretends to be a dict:

```python
>>> m.keys()
>>> m.items()
>>> m["my_key"]
>>> m["my_key"] = my_val
```

You can also explicitly ask for a dict version like so:
```python
m.to_dict()
```

Channels constructed with the `array` convenience class already have one of these as a `metadata` attribute:

```python
from intern import array

dataset = array("bossdb://...")
dataset.metadata.keys()
```
