### PR TITLE
Fix TypeError in non-cloudvolume case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ---
 
+## v1.3.3 (October 2022)
+
+-   **Fixes**
+    -   Resolves a TypeError when warning in the non-cloudvolume case.
+
 ## v1.3.2 (October 2022)
 
 -   **Fixes**

--- a/intern/convenience/array.py
+++ b/intern/convenience/array.py
@@ -48,7 +48,7 @@ try:
 except ModuleNotFoundError:
     HAS_CLOUDVOLUME = False
 
-warnings.simplefilter('once', 'CloudVolume')
+warnings.filterwarnings('once', 'CloudVolume')
 
 # A named tuple that represents a bossDB URI.
 bossdbURI = namedtuple(

--- a/intern/version/__init__.py
+++ b/intern/version/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.3.2"
+__version__ = "1.3.3"
 
 
 def check_version():


### PR DESCRIPTION
#100 added warnings in the event that CloudVolume is not installed. However, [`warnings.simplefilter`](https://docs.python.org/3/library/warnings.html#warnings.simplefilter) expects the second argument to be a class (a category of warning), not a string.

https://github.com/jhuapl-boss/intern/blob/e1c0b4ab18b70cdd27e7c9a94cb0a0e864e979f0/intern/convenience/array.py#L51

This results in an error if the warning actually occurs:
```
TypeError: issubclass() arg 2 must be a class, a tuple of classes, or a union
```
I've replaced this with [`warnings.filterwarnings`](https://docs.python.org/3/library/warnings.html#warnings.filterwarnings), which accepts a string for matching against warning messages.

(Discovered with @emmapbingham.)
