### PR TITLE
Adds c-order contiguous check

### DIFF
--- a/intern/service/boss/v1/volume.py
+++ b/intern/service/boss/v1/volume.py
@@ -65,6 +65,9 @@ class VolumeService_1(BaseVersion):
             session (requests.Session): HTTP session to use for request.
             send_opts (dictionary): Additional arguments to pass to session.send().
         """
+        if not numpyVolume.flags["C_CONTIGUOUS"]:
+            numpyVolume = np.ascontiguousarray(numpyVolume)
+
         if np.sum(numpyVolume) == 0:
             return
 

--- a/intern/service/boss/v1/volume.py
+++ b/intern/service/boss/v1/volume.py
@@ -65,8 +65,7 @@ class VolumeService_1(BaseVersion):
             session (requests.Session): HTTP session to use for request.
             send_opts (dictionary): Additional arguments to pass to session.send().
         """
-        if not numpyVolume.flags["C_CONTIGUOUS"]:
-            numpyVolume = np.ascontiguousarray(numpyVolume)
+        numpyVolume = np.ascontiguousarray(numpyVolume)
 
         if np.sum(numpyVolume) == 0:
             return

--- a/intern/service/dvid/volume.py
+++ b/intern/service/dvid/volume.py
@@ -124,9 +124,7 @@ class VolumeService(DVIDService):
         """
         # Check that the data array is C Contiguous
         blktypes = ["uint8blk", "labelblk", "rgba8blk"]
-
-        if not numpyVolume.flags["C_CONTIGUOUS"]:
-            numpyVolume = np.ascontiguousarray(numpyVolume)
+        numpyVolume = np.ascontiguousarray(numpyVolume)
 
         if resource._type == "tile":
             # Compress the data


### PR DESCRIPTION
Collaborators were having issues following tutorial code because intern would fail to upload cutouts for arrays that weren't c-contiguous. This is hidden in the docs somewhere but I figured it would be a better user experience if we convert it during the cutout for them. 