### PR TITLE
Drop dependency on PyPI mock package

### DIFF
--- a/intern/remote/boss/tests/test_remote_get_cutout.py
+++ b/intern/remote/boss/tests/test_remote_get_cutout.py
@@ -16,7 +16,7 @@ from intern.remote.boss import BossRemote
 from intern.resource.boss.resource import ChannelResource
 from intern.service.boss.volume import VolumeService
 from intern.service.boss.v1.volume import CacheMode
-from mock import patch, ANY
+from unittest.mock import patch, ANY
 import unittest
 
 

--- a/intern/remote/boss/tests/test_remote_list.py
+++ b/intern/remote/boss/tests/test_remote_list.py
@@ -15,7 +15,7 @@
 from intern.remote import Remote
 from intern.remote.boss import BossRemote
 import unittest
-from mock import patch
+from unittest.mock import patch
 
 
 class TestRemoteListMethods(unittest.TestCase):

--- a/intern/remote/dvid/tests/test_remote_config.py
+++ b/intern/remote/dvid/tests/test_remote_config.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from intern.remote.dvid import DVIDRemote
-from mock import patch, ANY
+from unittest.mock import patch, ANY
 import unittest
 
 

--- a/intern/service/boss/v1/tests/test_group.py
+++ b/intern/service/boss/v1/tests/test_group.py
@@ -16,7 +16,7 @@ from intern.service.boss.v1.project import ProjectService_1
 from intern.resource.boss.resource import *
 from requests import PreparedRequest, Response, Session, HTTPError
 import unittest
-from mock import patch
+from unittest.mock import patch
 
 
 class TestGroup(unittest.TestCase):

--- a/intern/service/boss/v1/tests/test_metadata.py
+++ b/intern/service/boss/v1/tests/test_metadata.py
@@ -17,7 +17,7 @@ from intern.resource.boss.resource import ChannelResource
 from intern.service.boss.httperrorlist import HTTPErrorList
 from requests import HTTPError, PreparedRequest, Response, Session
 import unittest
-from mock import patch
+from unittest.mock import patch
 
 
 class TestMetadata_v1(unittest.TestCase):

--- a/intern/service/boss/v1/tests/test_project.py
+++ b/intern/service/boss/v1/tests/test_project.py
@@ -16,7 +16,7 @@ from intern.service.boss.v1.project import ProjectService_1
 from intern.resource.boss.resource import *
 from requests import HTTPError, PreparedRequest, Response, Session
 import unittest
-from mock import patch
+from unittest.mock import patch
 
 
 class TestProject_v1(unittest.TestCase):

--- a/intern/service/boss/v1/tests/test_user.py
+++ b/intern/service/boss/v1/tests/test_user.py
@@ -16,7 +16,7 @@ from intern.service.boss.v1.project import ProjectService_1
 from intern.resource.boss.resource import *
 from requests import PreparedRequest, Response, Session, HTTPError
 import unittest
-from mock import patch
+from unittest.mock import patch
 
 
 class TestUser(unittest.TestCase):

--- a/intern/service/boss/v1/tests/test_user_role.py
+++ b/intern/service/boss/v1/tests/test_user_role.py
@@ -16,7 +16,7 @@ from intern.service.boss.v1.project import ProjectService_1
 from intern.resource.boss.resource import *
 from requests import PreparedRequest, Response, HTTPError
 import unittest
-from mock import patch
+from unittest.mock import patch
 
 
 class TestUserRole(unittest.TestCase):

--- a/intern/service/boss/v1/tests/test_volume.py
+++ b/intern/service/boss/v1/tests/test_volume.py
@@ -20,7 +20,7 @@ import blosc
 import numpy
 from requests import HTTPError, PreparedRequest, Response, Session
 import unittest
-from mock import patch, ANY
+from unittest.mock import patch, ANY
 
 
 class TestVolume_v1(unittest.TestCase):

--- a/intern/service/dvid/tests/test_project.py
+++ b/intern/service/dvid/tests/test_project.py
@@ -18,8 +18,8 @@ from intern.resource.dvid.resource import RepositoryResource
 import numpy
 from requests import HTTPError, PreparedRequest, Response, Session
 import unittest
-from mock import patch, ANY
-import mock
+from unittest.mock import patch, ANY
+from unittest import mock
 
 
 class TestProject(unittest.TestCase):

--- a/intern/service/dvid/tests/test_versioning.py
+++ b/intern/service/dvid/tests/test_versioning.py
@@ -17,8 +17,8 @@ from intern.resource.dvid.resource import DataInstanceResource
 import numpy
 from requests import HTTPError, PreparedRequest, Response, Session
 import unittest
-from mock import patch, ANY
-import mock
+from unittest.mock import patch, ANY
+from unittest import mock
 
 
 class TestVersioning(unittest.TestCase):

--- a/intern/service/dvid/tests/test_volume.py
+++ b/intern/service/dvid/tests/test_volume.py
@@ -17,8 +17,8 @@ from intern.resource.dvid.resource import DataInstanceResource
 import numpy
 from requests import HTTPError, PreparedRequest, Response, Session
 import unittest
-from mock import patch, ANY
-import mock
+from unittest.mock import patch, ANY
+from unittest import mock
 
 
 class TestVolume(unittest.TestCase):

--- a/intern/service/mesh/tests/test_meshing.py
+++ b/intern/service/mesh/tests/test_meshing.py
@@ -16,8 +16,8 @@ from intern.service.mesh.service import MeshService
 from intern.service.mesh.service import VoxelUnits
 import numpy
 import unittest
-from mock import patch, ANY
-import mock
+from unittest.mock import patch, ANY
+from unittest import mock
 
 
 class TestMesh(unittest.TestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ numpy
 requests>=2.11.1
 blosc>=1.4.4
 six
-mock
 nose2
 joblib
 psutil


### PR DESCRIPTION
Use `unittest.mock` (available in Python 3.3+) instead. See also: https://fedoraproject.org/wiki/Changes/DeprecatePythonMock