### PR TITLE
Fix single index cutouts for cloudvolume volume provider datasets

### DIFF
--- a/intern/service/cv/volume.py
+++ b/intern/service/cv/volume.py
@@ -66,8 +66,9 @@ class VolumeService(CloudVolumeService):
             x_range[0] : x_range[1], y_range[0] : y_range[1], z_range[0] : z_range[1]
         ]
 
-        # Remove channel dimension if num_channel = 1
-        data = np.squeeze(data)
+        # Remove channel dimension
+        if data.ndim == 4:
+            data = data[:,:,:,0]
         return data
 
     def delete_data(self, resource, res, x_range, y_range, z_range):


### PR DESCRIPTION
Currently, pulling single index cutouts such as the one in https://github.com/aplbrain/bossdb_cookbook/blob/main/notebooks/Accessing-Lower-Resolution-Versions-Of-Data-From-BossDB.ipynb

error out because the cloud volume cutout is squeezed before being passed to the array convenience function, which tries to roll over the axis but because of the squeeze the array is now 2-dimensional. 

This fix addresses this issue by removing the squeeze and directly indexing the cutout to remove the channel dimension.