### PR TITLE
Fix cv remote instantiation

### DIFF
--- a/intern/convenience/array.py
+++ b/intern/convenience/array.py
@@ -715,7 +715,14 @@ if HAS_CLOUDVOLUME:
                 "cloudpath": "",
                 "bucket": "bossdb-open-data",
             }
-            self._cv = CloudVolumeRemote(self.cv_config)
+            # NOTE: Hotfix to translate the array configuration to a cloudvolume 
+            # remote configuration. The CV Remote does not distinguish between 
+            # bucket and path as separate attributes currently.
+            self._cv = CloudVolumeRemote({
+                "protocol": self.cv_config["protocol"],
+                "cloudpath": f"{self.cv_config['bucket']}/{self.cv_config['cloudpath']}"
+            })
+
 
         def get_remote(self):
             return self._cv


### PR DESCRIPTION
Right now the remote has the wrong cloudpath when initialized via intern.array. Reproduce:

```
em = array('bossdb://microns/minnie65_8x8x40/em', resolution=mip)
print(em.volume_provider._cv.cloudvolume().resolution)
```

The remote isn't used for cutouts, but is useful for extracting metadata that is cloudvolume specific, such as `voxel_offset`. 

